### PR TITLE
Add "subspecies"

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -593,7 +593,7 @@ pl_sb_uninflected_s_complete = [
     "mumps",
 
 # MISCELLANEOUS OTHERS...
-    "diabetes", "jackanapes", "series", "species", "rabies",
+    "diabetes", "jackanapes", "series", "species", "subspecies", "rabies",
     "chassis", "innings", "news", "mews", "haggis",
 ]
 


### PR DESCRIPTION
Fixes plural -> singular handling for one word. I couldn't think of other cases.
