### PR TITLE
Minor bug fix in engine.singular_noun()

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -2385,10 +2385,14 @@ class engine:
         if len(lowersplit) >= 3:
             for numword in range(1, len(lowersplit)-1):
                 if lowersplit[numword] in pl_prep_list_da:
-                    return ' '.join(lowersplit[:numword-1] + 
-                        [self._sinoun(lowersplit[numword-1], 1, gender=gender) +
-                        '-' + lowersplit[numword] + '-']) + \
-                        ' '.join(lowersplit[(numword+1):])
+                    v = self._sinoun(lowersplit[numword-1], 1, gender=gender)
+                    if v:
+                        return ' '.join(lowersplit[:numword-1] + 
+                                        [v +
+                                         '-' + lowersplit[numword] + '-']) + \
+                                         ' '.join(lowersplit[(numword+1):])
+                    else:
+                        return False
 
 
 # HANDLE PRONOUNS


### PR DESCRIPTION
Hi Paul,

when issueing for example

engine.singular_noun('bag-of-words')

I got this error:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "inflect.py", line 1755, in singular_noun
    sing = self._sinoun(word, count=count, gender=gender)
  File "inflect.py", line 2390, in _sinoun
    '-' + lowersplit[numword] + '-']) + \
TypeError: unsupported operand type(s) for +: 'bool' and 'str'

if the _sinoun call one of the earlier terms evaluates to False, the + with the strings fail. I assume the expected behavior should be to return False, that's what I've changed it to do.

Hope it helps.

Cheers,

Maarten Grachten
