### PR TITLE
Open README.rst explicitly as utf-8 in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,17 @@
 from distutils.core import setup
 import os
+import sys
 
 import inflect
 
 
 here = os.path.dirname(__file__)
 readme_path = os.path.join(here, 'README.rst')
-readme = open(readme_path).read()
+
+if sys.version_info >= (3, 0):
+    readme = open(readme_path, encoding='utf-8').read()
+else:
+    readme = open(readme_path).read()
 
 setup(
     name='inflect',


### PR DESCRIPTION
When building with Python 3, reading the contents of README.rst into long_description can be problematic. Python 3 will attempt to decode the file, and whether it can correctly do so as utf-8 depends on the locale settings.

$ LANG=C python3 setup.py build
Traceback (most recent call last):
  File "setup.py", line 9, in <module>
    readme = open(readme_path).read()
  File "/usr/lib64/python3.3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 47693: ordinal not in range(128)

This fixes that by adding an encoding parameter to open() available in Python 3.
