### PR TITLE
Modernize codebase

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -2116,10 +2116,6 @@ class engine:
         elif isinstance(obj, ast.NameConstant):
             return obj.value
 
-        # For python versions below 3.4
-        elif isinstance(obj, ast.Name) and (obj.id in ["True", "False", "None"]):
-            return string_to_constant[obj.id]
-
         # Probably passed a variable name.
         # Or passed a single word without wrapping it in quotes as an argument
         # ex: p.inflect("I plural(see)") instead of p.inflect("I plural('see')")

--- a/inflect.py
+++ b/inflect.py
@@ -1919,6 +1919,7 @@ class engine:
         self.si_sb_user_defined = []
         self.A_a_user_defined = []
         self.thegender = "neuter"
+        self._number_args = None
 
     deprecated_methods = dict(
         pl="plural",
@@ -2121,7 +2122,9 @@ class engine:
         # ex: p.inflect("I plural(see)") instead of p.inflect("I plural('see')")
         raise NameError(f"name '{obj.id}' is not defined")
 
-    def _string_to_substitute(self, mo: Match, methods_dict: Dict[str, Callable]) -> str:
+    def _string_to_substitute(
+        self, mo: Match, methods_dict: Dict[str, Callable]
+    ) -> str:
         """
         Return the string to be substituted for the match.
         """
@@ -3506,7 +3509,7 @@ class engine:
 
     def hundfn(self, hundreds: int, tens: int, units: int, mindex: int) -> str:
         if hundreds:
-            andword = f" {self.number_args['andword']} " if tens or units else ""
+            andword = f" {self._number_args['andword']} " if tens or units else ""
             # use unit not unitfn as simpler
             return (
                 f"{unit[hundreds]} hundred{andword}"
@@ -3519,18 +3522,18 @@ class engine:
     def group1sub(self, mo: Match) -> str:
         units = int(mo.group(1))
         if units == 1:
-            return f" {self.number_args['one']}, "
+            return f" {self._number_args['one']}, "
         elif units:
             return f"{unit[units]}, "
         else:
-            return f" {self.number_args['zero']}, "
+            return f" {self._number_args['zero']}, "
 
     def group1bsub(self, mo: Match) -> str:
         units = int(mo.group(1))
         if units:
             return f"{unit[units]}, "
         else:
-            return f" {self.number_args['zero']}, "
+            return f" {self._number_args['zero']}, "
 
     def group2sub(self, mo: Match) -> str:
         tens = int(mo.group(1))
@@ -3538,25 +3541,25 @@ class engine:
         if tens:
             return f"{self.tenfn(tens, units)}, "
         if units:
-            return f" {self.number_args['zero']} {unit[units]}, "
-        return f" {self.number_args['zero']} {self.number_args['zero']}, "
+            return f" {self._number_args['zero']} {unit[units]}, "
+        return f" {self._number_args['zero']} {self._number_args['zero']}, "
 
     def group3sub(self, mo: Match) -> str:
         hundreds = int(mo.group(1))
         tens = int(mo.group(2))
         units = int(mo.group(3))
         if hundreds == 1:
-            hunword = f" {self.number_args['one']}"
+            hunword = f" {self._number_args['one']}"
         elif hundreds:
             hunword = str(unit[hundreds])
         else:
-            hunword = f" {self.number_args['zero']}"
+            hunword = f" {self._number_args['zero']}"
         if tens:
             tenword = self.tenfn(tens, units)
         elif units:
-            tenword = f" {self.number_args['zero']} {unit[units]}"
+            tenword = f" {self._number_args['zero']} {unit[units]}"
         else:
-            tenword = f" {self.number_args['zero']} {self.number_args['zero']}"
+            tenword = f" {self._number_args['zero']} {self._number_args['zero']}"
         return f"{hunword} {tenword}, "
 
     def hundsub(self, mo: Match) -> str:
@@ -3586,9 +3589,9 @@ class engine:
             num = re.sub(r"(\d)(\d)", self.group2sub, num, 1)
             num = re.sub(r"(\d)", self.group1sub, num, 1)
         elif int(num) == 0:
-            num = self.number_args["zero"]
+            num = self._number_args["zero"]
         elif int(num) == 1:
-            num = self.number_args["one"]
+            num = self._number_args["one"]
         else:
             num = num.lstrip().lstrip("0")
             self.mill_count = 0
@@ -3627,7 +3630,7 @@ class engine:
 
         parameters not remembered from last call. Departure from Perl version.
         """
-        self.number_args = dict(andword=andword, zero=zero, one=one)
+        self._number_args = {"andword": andword, "zero": zero, "one": one}
         num = str(num)
 
         # Handle "stylistic" conversions (up to a given threshold)...

--- a/inflect.py
+++ b/inflect.py
@@ -2567,7 +2567,7 @@ class engine:
         # there is no more than one word following)
         # degree Celsius => degrees Celsius but degree
         # fahrenheit hour => degree fahrenheit hours
-        if len(split) >= 2 and split[-2] in ["degree"]:
+        if len(split) >= 2 and split[-2] == "degree":
             return " ".join([self._plnoun(first)] + split[1:])
 
         lowered_split = lowered.split("-")

--- a/inflect.py
+++ b/inflect.py
@@ -1735,7 +1735,9 @@ plverb_ambiguous_pres = {
     "views": "view",
 }
 
-plverb_ambiguous_pres_keys = enclose("|".join(plverb_ambiguous_pres))
+plverb_ambiguous_pres_keys = re.compile(
+    fr"^({enclose('|'.join(plverb_ambiguous_pres))})((\s.*)?)$", re.IGNORECASE
+)
 
 
 plverb_irregular_non_pres = (
@@ -1755,8 +1757,8 @@ plverb_irregular_non_pres = (
     "should",
 )
 
-plverb_ambiguous_non_pres = enclose(
-    "|".join(("thought", "saw", "bent", "will", "might", "cut"))
+plverb_ambiguous_non_pres = re.compile(
+    r"^((?:thought|saw|bent|will|might|cut))((\s.*)?)$", re.IGNORECASE
 )
 
 # "..oes" -> "..oe" (the rest are "..oes" -> "o")
@@ -1773,7 +1775,9 @@ pl_count_one = ("1", "a", "an", "one", "each", "every", "this", "that")
 
 pl_adj_special = {"a": "some", "an": "some", "this": "these", "that": "those"}
 
-pl_adj_special_keys = enclose("|".join(pl_adj_special))
+pl_adj_special_keys = re.compile(
+    fr"^({enclose('|'.join(pl_adj_special))})$", re.IGNORECASE
+)
 
 pl_adj_poss = {
     "my": "our",
@@ -1784,7 +1788,7 @@ pl_adj_poss = {
     "their": "their",
 }
 
-pl_adj_poss_keys = enclose("|".join(pl_adj_poss))
+pl_adj_poss_keys = re.compile(fr"^({enclose('|'.join(pl_adj_poss))})$", re.IGNORECASE)
 
 
 # 2. INDEFINITE ARTICLES
@@ -1793,29 +1797,32 @@ pl_adj_poss_keys = enclose("|".join(pl_adj_poss))
 # CONSONANT FOLLOWED BY ANOTHER CONSONANT, AND WHICH ARE NOT LIKELY
 # TO BE REAL WORDS (OH, ALL RIGHT THEN, IT'S JUST MAGIC!)
 
-A_abbrev = r"""
+A_abbrev = re.compile(
+    r"""
 (?! FJO | [HLMNS]Y.  | RY[EO] | SQU
   | ( F[LR]? | [HL] | MN? | N | RH? | S[CHKLMNPTVW]? | X(YL)?) [AEIOU])
 [FHLMNRSX][A-Z]
-"""
+""",
+    re.VERBOSE,
+)
 
 # THIS PATTERN CODES THE BEGINNINGS OF ALL ENGLISH WORDS BEGINING WITH A
 # 'y' FOLLOWED BY A CONSONANT. ANY OTHER Y-CONSONANT PREFIX THEREFORE
 # IMPLIES AN ABBREVIATION.
 
-A_y_cons = "y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt)"
+A_y_cons = re.compile(r"^(y(b[lor]|cl[ea]|fere|gg|p[ios]|rou|tt))", re.IGNORECASE)
 
 # EXCEPTIONS TO EXCEPTIONS
 
-A_explicit_a = enclose("|".join(("unabomber", "unanimous", "US")))
+A_explicit_a = re.compile(r"^((?:unabomber|unanimous|US))", re.IGNORECASE)
 
-A_explicit_an = enclose(
-    "|".join(("euler", "hour(?!i)", "heir", "honest", "hono[ur]", "mpeg"))
+A_explicit_an = re.compile(
+    r"^((?:euler|hour(?!i)|heir|honest|hono[ur]|mpeg))", re.IGNORECASE
 )
 
-A_ordinal_an = enclose("|".join(("[aefhilmnorsx]-?th",)))
+A_ordinal_an = re.compile(r"^([aefhilmnorsx]-?th)", re.IGNORECASE)
 
-A_ordinal_a = enclose("|".join(("[bcdgjkpqtuvwyz]-?th",)))
+A_ordinal_a = re.compile(r"^([bcdgjkpqtuvwyz]-?th)", re.IGNORECASE)
 
 
 # NUMERICAL INFLECTIONS
@@ -1847,7 +1854,7 @@ ordinal = dict(
     twelve="twelfth",
 )
 
-ordinal_suff = "|".join(ordinal)
+ordinal_suff = re.compile(fr"({'|'.join(ordinal)})\Z")
 
 
 # NUMBERS
@@ -1905,6 +1912,70 @@ no_classical = {k: False for k in def_classical}
 
 # Maps strings to built-in constant types
 string_to_constant = {"True": True, "False": False, "None": None}
+
+
+# Pre-compiled regular expression objects
+DOLLAR_DIGITS = re.compile(r"\$(\d+)")
+FUNCTION_CALL = re.compile(r"((\w+)\([^)]*\)*)", re.IGNORECASE)
+PARTITION_WORD = re.compile(r"\A(\s*)(.+?)(\s*)\Z")
+PL_SB_POSTFIX_ADJ_STEMS_RE = re.compile(
+    fr"^(?:{pl_sb_postfix_adj_stems})$", re.IGNORECASE
+)
+PL_SB_PREP_DUAL_COMPOUND_RE = re.compile(
+    fr"^(?:{pl_sb_prep_dual_compound})$", re.IGNORECASE
+)
+DENOMINATOR = re.compile(r"(?P<denominator>.+)( (per|a) .+)")
+PLVERB_SPECIAL_S_RE = re.compile(fr"^({plverb_special_s})$")
+WHITESPACE = re.compile(r"\s")
+ENDS_WITH_S = re.compile(r"^(.*[^s])s$", re.IGNORECASE)
+ENDS_WITH_APOSTROPHE_S = re.compile(r"^(.*)'s?$")
+INDEFINITE_ARTICLE_TEST = re.compile(r"\A(\s*)(?:an?\s+)?(.+?)(\s*)\Z", re.IGNORECASE)
+SPECIAL_AN = re.compile(r"^[aefhilmnorsx]$", re.IGNORECASE)
+SPECIAL_A = re.compile(r"^[bcdgjkpqtuvwyz]$", re.IGNORECASE)
+SPECIAL_ABBREV_AN = re.compile(r"^[aefhilmnorsx][.-]", re.IGNORECASE)
+SPECIAL_ABBREV_A = re.compile(r"^[a-z][.-]", re.IGNORECASE)
+CONSONANTS = re.compile(r"^[^aeiouy]", re.IGNORECASE)
+ARTICLE_SPECIAL_EU = re.compile(r"^e[uw]", re.IGNORECASE)
+ARTICLE_SPECIAL_ONCE = re.compile(r"^onc?e\b", re.IGNORECASE)
+ARTICLE_SPECIAL_ONETIME = re.compile(r"^onetime\b", re.IGNORECASE)
+ARTICLE_SPECIAL_UNIT = re.compile(r"^uni([^nmd]|mo)", re.IGNORECASE)
+ARTICLE_SPECIAL_UBA = re.compile(r"^u[bcfghjkqrst][aeiou]", re.IGNORECASE)
+ARTICLE_SPECIAL_UKR = re.compile(r"^ukr", re.IGNORECASE)
+SPECIAL_CAPITALS = re.compile(r"^U[NK][AIEO]?")
+VOWELS = re.compile(r"^[aeiou]", re.IGNORECASE)
+
+DIGIT_GROUP = re.compile(r"(\d)")
+TWO_DIGITS = re.compile(r"(\d)(\d)")
+THREE_DIGITS = re.compile(r"(\d)(\d)(\d)")
+THREE_DIGITS_WORD = re.compile(r"(\d)(\d)(\d)(?=\D*\Z)")
+TWO_DIGITS_WORD = re.compile(r"(\d)(\d)(?=\D*\Z)")
+ONE_DIGIT_WORD = re.compile(r"(\d)(?=\D*\Z)")
+
+FOUR_DIGIT_COMMA = re.compile(r"(\d)(\d{3}(?:,|\Z))")
+NON_DIGIT = re.compile(r"\D")
+WHITESPACES_COMMA = re.compile(r"\s+,")
+COMMA_WORD = re.compile(r", (\S+)\s+\Z")
+WHITESPACES = re.compile(r"\s+")
+
+
+PRESENT_PARTICIPLE_REPLACEMENTS = (
+    (re.compile(r"ie$"), r"y"),
+    (
+        re.compile(r"ue$"),
+        r"u",
+    ),  # TODO: isn't ue$ -> u encompassed in the following rule?
+    (re.compile(r"([auy])e$"), r"\g<1>"),
+    (re.compile(r"ski$"), r"ski"),
+    (re.compile(r"[^b]i$"), r""),
+    (re.compile(r"^(are|were)$"), r"be"),
+    (re.compile(r"^(had)$"), r"hav"),
+    (re.compile(r"^(hoe)$"), r"\g<1>"),
+    (re.compile(r"([^e])e$"), r"\g<1>"),
+    (re.compile(r"er$"), r"er"),
+    (re.compile(r"([^aeiou][aeiouy]([bdgmnprst]))$"), r"\g<1>\g<2>"),
+)
+
+DIGIT = re.compile(r"\d")
 
 
 class engine:
@@ -2021,8 +2092,8 @@ class engine:
             if mo:
                 if wordlist[i + 1] is None:
                     return None
-                pl = re.sub(
-                    r"\$(\d+)", r"\\1", wordlist[i + 1]
+                pl = DOLLAR_DIGITS.sub(
+                    r"\\1", wordlist[i + 1]
                 )  # change $n to \n for expand
                 return mo.expand(pl)
         return None
@@ -2185,8 +2256,7 @@ class engine:
         }
 
         # Regular expression to find Python's function call syntax
-        functions_re = re.compile(r"((\w+)\([^)]*\)*)", re.IGNORECASE)
-        output = functions_re.sub(
+        output = FUNCTION_CALL.sub(
             lambda mo: self._string_to_substitute(mo, methods_dict), text
         )
         self.persistent_count = save_persistent_count
@@ -2214,7 +2284,7 @@ class engine:
         return " ".join(result)
 
     def partition_word(self, text: str) -> Tuple[str, str, str]:
-        mo = re.search(r"\A(\s*)(.+?)(\s*)\Z", text)
+        mo = PARTITION_WORD.search(text)
         if mo:
             return mo.group(1), mo.group(2), mo.group(3)
         else:
@@ -2535,12 +2605,12 @@ class engine:
 
         # HANDLE COMPOUNDS ("Governor General", "mother-in-law", "aide-de-camp", ETC.)
 
-        mo = re.search(fr"^(?:{pl_sb_postfix_adj_stems})$", word, re.IGNORECASE)
+        mo = PL_SB_POSTFIX_ADJ_STEMS_RE.search(word)
         if mo and mo.group(2) != "":
             return f"{self._plnoun(mo.group(1), 2)}{mo.group(2)}"
 
         if " a " in lowered or "-a-" in lowered:
-            mo = re.search(fr"^(?:{pl_sb_prep_dual_compound})$", word, re.IGNORECASE)
+            mo = PL_SB_PREP_DUAL_COMPOUND_RE.search(word)
             if mo and mo.group(2) != "" and mo.group(3) != "":
                 return (
                     f"{self._plnoun(mo.group(1), 2)}"
@@ -2558,7 +2628,7 @@ class engine:
                     )
 
         # only pluralize denominators in units
-        mo = re.search(r"(?P<denominator>.+)( (per|a) .+)", lowered)
+        mo = DENOMINATOR.search(lowered)
         if mo:
             index = len(mo.group("denominator"))
             return f"{self._plnoun(word[:index])}{word[index:]}"
@@ -2828,10 +2898,10 @@ class engine:
 
         # HANDLE SPECIAL CASES
 
-        mo = re.search(fr"^({plverb_special_s})$", word)
+        mo = PLVERB_SPECIAL_S_RE.search(word)
         if mo:
             return False
-        if re.search(r"\s", word):
+        if WHITESPACE.search(word):
             return False
         lowered = word.lower()
         if lowered == "quizzes":
@@ -2855,7 +2925,7 @@ class engine:
         if lowered.endswith("oes") and len(word) > 3:
             return lowered[:-2]
 
-        mo = re.search(r"^(.*[^s])s$", word, re.IGNORECASE)
+        mo = ENDS_WITH_S.search(word)
         if mo:
             return mo.group(1)
 
@@ -2873,17 +2943,13 @@ class engine:
 
         # HANDLE AMBIGUOUS PRESENT TENSES  (SIMPLE AND COMPOUND)
 
-        mo = re.search(
-            fr"^({plverb_ambiguous_pres_keys})((\s.*)?)$", word, re.IGNORECASE
-        )
+        mo = plverb_ambiguous_pres_keys.search(word)
         if mo:
             return f"{plverb_ambiguous_pres[mo.group(1).lower()]}{mo.group(2)}"
 
         # HANDLE AMBIGUOUS PRETERITE AND PERFECT TENSES
 
-        mo = re.search(
-            fr"^({plverb_ambiguous_non_pres})((\s.*)?)$", word, re.IGNORECASE
-        )
+        mo = plverb_ambiguous_non_pres.search(word)
         if mo:
             return word
 
@@ -2907,17 +2973,17 @@ class engine:
 
         # HANDLE KNOWN CASES
 
-        mo = re.search(fr"^({pl_adj_special_keys})$", word, re.IGNORECASE)
+        mo = pl_adj_special_keys.search(word)
         if mo:
             return pl_adj_special[mo.group(1).lower()]
 
         # HANDLE POSSESSIVES
 
-        mo = re.search(fr"^({pl_adj_poss_keys})$", word, re.IGNORECASE)
+        mo = pl_adj_poss_keys.search(word)
         if mo:
             return pl_adj_poss[mo.group(1).lower()]
 
-        mo = re.search(r"^(.*)'s?$", word)
+        mo = ENDS_WITH_APOSTROPHE_S.search(word)
         if mo:
             pl = self.plural_noun(mo.group(1))
             trailing_s = "" if pl[-1] == "s" else "s"
@@ -2986,7 +3052,7 @@ class engine:
 
         # HANDLE COMPOUNDS ("Governor General", "mother-in-law", "aide-de-camp", ETC.)
 
-        mo = re.search(fr"^(?:{pl_sb_postfix_adj_stems})$", word, re.IGNORECASE)
+        mo = PL_SB_POSTFIX_ADJ_STEMS_RE.search(word)
         if mo and mo.group(2) != "":
             return f"{self._sinoun(mo.group(1), 1, gender=gender)}{mo.group(2)}"
 
@@ -3281,7 +3347,7 @@ class engine:
         Whitespace at the start and end is preserved.
 
         """
-        mo = re.search(r"\A(\s*)(?:an?\s+)?(.+?)(\s*)\Z", text, re.IGNORECASE)
+        mo = INDEFINITE_ARTICLE_TEST.search(text)
         if mo:
             word = mo.group(2)
             if not word:
@@ -3306,73 +3372,39 @@ class engine:
         if value is not None:
             return f"{value} {word}"
 
-        # HANDLE ORDINAL FORMS
-
-        for a in ((fr"^({A_ordinal_a})", "a"), (fr"^({A_ordinal_an})", "an")):
-            mo = re.search(a[0], word, re.IGNORECASE)
-            if mo:
-                return f"{a[1]} {word}"
-
-        # HANDLE SPECIAL CASES
-
-        for a in (
-            (fr"^({A_explicit_an})", "an"),
-            (r"^[aefhilmnorsx]$", "an"),
-            (r"^[bcdgjkpqtuvwyz]$", "a"),
+        for regexen, article in (
+            # HANDLE ORDINAL FORMS
+            (A_ordinal_a, "a"),
+            (A_ordinal_an, "an"),
+            # HANDLE SPECIAL CASES
+            (A_explicit_an, "an"),
+            (SPECIAL_AN, "an"),
+            (SPECIAL_A, "a"),
+            # HANDLE ABBREVIATIONS
+            (A_abbrev, "an"),
+            (SPECIAL_ABBREV_AN, "an"),
+            (SPECIAL_ABBREV_A, "a"),
+            # HANDLE CONSONANTS
+            (CONSONANTS, "a"),
+            # HANDLE SPECIAL VOWEL-FORMS
+            (ARTICLE_SPECIAL_EU, "a"),
+            (ARTICLE_SPECIAL_ONCE, "a"),
+            (ARTICLE_SPECIAL_ONETIME, "a"),
+            (ARTICLE_SPECIAL_UNIT, "a"),
+            (ARTICLE_SPECIAL_UBA, "a"),
+            (ARTICLE_SPECIAL_UKR, "a"),
+            (A_explicit_a, "a"),
+            # HANDLE SPECIAL CAPITALS
+            (SPECIAL_CAPITALS, "a"),
+            # HANDLE VOWELS
+            (VOWELS, "an"),
+            # HANDLE y...
+            # (BEFORE CERTAIN CONSONANTS IMPLIES (UNNATURALIZED) "i.." SOUND)
+            (A_y_cons, "an"),
         ):
-            mo = re.search(a[0], word, re.IGNORECASE)
-            if mo:
-                return f"{a[1]} {word}"
-
-        # HANDLE ABBREVIATIONS
-
-        for regexen, article, re_flag in (
-            (fr"({A_abbrev})", "an", re.VERBOSE),
-            (r"^[aefhilmnorsx][.-]", "an", re.IGNORECASE),
-            (r"^[a-z][.-]", "a", re.IGNORECASE),
-        ):
-            mo = re.search(regexen, word, re_flag)
+            mo = regexen.search(word)
             if mo:
                 return f"{article} {word}"
-
-        # HANDLE CONSONANTS
-
-        mo = re.search(r"^[^aeiouy]", word, re.IGNORECASE)
-        if mo:
-            return f"a {word}"
-
-        # HANDLE SPECIAL VOWEL-FORMS
-
-        for a in (
-            (r"^e[uw]", "a"),
-            (r"^onc?e\b", "a"),
-            (r"^onetime\b", "a"),
-            (r"^uni([^nmd]|mo)", "a"),
-            (r"^u[bcfghjkqrst][aeiou]", "a"),
-            (r"^ukr", "a"),
-            (fr"^({A_explicit_a})", "a"),
-        ):
-            mo = re.search(a[0], word, re.IGNORECASE)
-            if mo:
-                return f"{a[1]} {word}"
-
-        # HANDLE SPECIAL CAPITALS
-
-        mo = re.search(r"^U[NK][AIEO]?", word)
-        if mo:
-            return f"a {word}"
-
-        # HANDLE VOWELS
-
-        mo = re.search(r"^[aeiou]", word, re.IGNORECASE)
-        if mo:
-            return f"an {word}"
-
-        # HANDLE y... (BEFORE CERTAIN CONSONANTS IMPLIES (UNNATURALIZED) "i.." SOUND)
-
-        mo = re.search(fr"^({A_y_cons})", word, re.IGNORECASE)
-        if mo:
-            return f"an {word}"
 
         # OTHERWISE, GUESS "a"
         return f"a {word}"
@@ -3400,7 +3432,7 @@ class engine:
 
         if count is None:
             count = 0
-        mo = re.search(r"\A(\s*)(.+?)(\s*)\Z", text)
+        mo = PARTITION_WORD.search(text)
         if mo:
             pre = mo.group(1)
             word = mo.group(2)
@@ -3424,21 +3456,10 @@ class engine:
 
         """
         plv = self.plural_verb(word, 2)
+        ans = plv
 
-        for pat, repl in (
-            (r"ie$", r"y"),
-            (r"ue$", r"u"),  # TODO: isn't ue$ -> u encompassed in the following rule?
-            (r"([auy])e$", r"\g<1>"),
-            (r"ski$", r"ski"),
-            (r"[^b]i$", r""),
-            (r"^(are|were)$", r"be"),
-            (r"^(had)$", r"hav"),
-            (r"^(hoe)$", r"\g<1>"),
-            (r"([^e])e$", r"\g<1>"),
-            (r"er$", r"er"),
-            (r"([^aeiou][aeiouy]([bdgmnprst]))$", r"\g<1>\g<2>"),
-        ):
-            (ans, num) = re.subn(pat, repl, plv)
+        for regexen, repl in PRESENT_PARTICIPLE_REPLACEMENTS:
+            ans, num = regexen.subn(repl, plv)
             if num:
                 return f"{ans}ing"
         return f"{ans}ing"
@@ -3455,7 +3476,7 @@ class engine:
         ordinal('one') returns 'first'
 
         """
-        if re.match(r"\d", str(num)):
+        if DIGIT.match(str(num)):
             if isinstance(num, (int, float)):
                 n = int(num)
             else:
@@ -3478,10 +3499,10 @@ class engine:
             # Mad props to Damian Conway (?) whose ordinal()
             # algorithm is type-bendy enough to foil MyPy
             str_num: str = num  # type:	ignore[assignment]
-            mo = re.search(fr"({ordinal_suff})\Z", str_num)
+            mo = ordinal_suff.search(str_num)
             if mo:
                 post = ordinal[mo.group(1)]
-                rval = re.sub(fr"({ordinal_suff})\Z", post, str_num)
+                rval = ordinal_suff.sub(post, str_num)
             else:
                 rval = f"{str_num}th"
             return rval
@@ -3580,14 +3601,14 @@ class engine:
         # pdb.set_trace()
 
         if group == 1:
-            num = re.sub(r"(\d)", self.group1sub, num)
+            num = DIGIT_GROUP.sub(self.group1sub, num)
         elif group == 2:
-            num = re.sub(r"(\d)(\d)", self.group2sub, num)
-            num = re.sub(r"(\d)", self.group1bsub, num, 1)
+            num = TWO_DIGITS.sub(self.group2sub, num)
+            num = DIGIT_GROUP.sub(self.group1bsub, num, 1)
         elif group == 3:
-            num = re.sub(r"(\d)(\d)(\d)", self.group3sub, num)
-            num = re.sub(r"(\d)(\d)", self.group2sub, num, 1)
-            num = re.sub(r"(\d)", self.group1sub, num, 1)
+            num = THREE_DIGITS.sub(self.group3sub, num)
+            num = TWO_DIGITS.sub(self.group2sub, num, 1)
+            num = DIGIT_GROUP.sub(self.group1sub, num, 1)
         elif int(num) == 0:
             num = self._number_args["zero"]
         elif int(num) == 1:
@@ -3596,12 +3617,12 @@ class engine:
             num = num.lstrip().lstrip("0")
             self.mill_count = 0
             # surely there's a better way to do the next bit
-            mo = re.search(r"(\d)(\d)(\d)(?=\D*\Z)", num)
+            mo = THREE_DIGITS_WORD.search(num)
             while mo:
-                num = re.sub(r"(\d)(\d)(\d)(?=\D*\Z)", self.hundsub, num, 1)
-                mo = re.search(r"(\d)(\d)(\d)(?=\D*\Z)", num)
-            num = re.sub(r"(\d)(\d)(?=\D*\Z)", self.tensub, num, 1)
-            num = re.sub(r"(\d)(?=\D*\Z)", self.unitsub, num, 1)
+                num = THREE_DIGITS_WORD.sub(self.hundsub, num, 1)
+                mo = THREE_DIGITS_WORD.search(num)
+            num = TWO_DIGITS_WORD.sub(self.tensub, num, 1)
+            num = ONE_DIGIT_WORD.sub(self.unitsub, num, 1)
         return num
 
     def number_to_words(
@@ -3637,7 +3658,7 @@ class engine:
         if threshold is not None and float(num) > threshold:
             spnum = num.split(".", 1)
             while comma:
-                (spnum[0], n) = re.subn(r"(\d)(\d{3}(?:,|\Z))", r"\1,\2", spnum[0])
+                (spnum[0], n) = FOUR_DIGIT_COMMA.subn(r"\1,\2", spnum[0])
                 if n == 0:
                     break
             try:
@@ -3681,7 +3702,7 @@ class engine:
         for i in range(loopstart, len(chunks)):
             chunk = chunks[i]
             # remove all non numeric \D
-            chunk = re.sub(r"\D", "", chunk)
+            chunk = NON_DIGIT.sub("", chunk)
             if chunk == "":
                 chunk = "0"
 
@@ -3692,11 +3713,11 @@ class engine:
 
             if chunk[-2:] == ", ":
                 chunk = chunk[:-2]
-            chunk = re.sub(r"\s+,", ",", chunk)
+            chunk = WHITESPACES_COMMA.sub(",", chunk)
 
             if group == 0 and first:
-                chunk = re.sub(r", (\S+)\s+\Z", f" {andword} \\1", chunk)
-            chunk = re.sub(r"\s+", " ", chunk)
+                chunk = COMMA_WORD.sub(f" {andword} \\1", chunk)
+            chunk = WHITESPACES.sub(" ", chunk)
             # chunk = re.sub(r"(\A\s|\s\Z)", self.blankfn, chunk)
             chunk = chunk.strip()
             if first:
@@ -3709,11 +3730,9 @@ class engine:
 
         if myord and numchunks:
             # TODO: can this be just one re as it is in perl?
-            mo = re.search(fr"({ordinal_suff})\Z", numchunks[-1])
+            mo = ordinal_suff.search(numchunks[-1])
             if mo:
-                numchunks[-1] = re.sub(
-                    fr"({ordinal_suff})\Z", ordinal[mo.group(1)], numchunks[-1]
-                )
+                numchunks[-1] = ordinal_suff.sub(ordinal[mo.group(1)], numchunks[-1])
             else:
                 numchunks[-1] += "th"
 

--- a/inflect.py
+++ b/inflect.py
@@ -3601,27 +3601,6 @@ class engine:
             num = re.sub(r"(\d)(?=\D*\Z)", self.unitsub, num, 1)
         return num
 
-    def blankfn(self, mo):
-        """do a global blank replace
-        TODO: surely this can be done with an option to re.sub
-              rather than this fn
-        """
-        return ""
-
-    def commafn(self, mo):
-        """do a global ',' replace
-        TODO: surely this can be done with an option to re.sub
-              rather than this fn
-        """
-        return ","
-
-    def spacefn(self, mo):
-        """do a global ' ' replace
-        TODO: surely this can be done with an option to re.sub
-              rather than this fn
-        """
-        return " "
-
     def number_to_words(
         self,
         num: Union[int, str],
@@ -3699,7 +3678,7 @@ class engine:
         for i in range(loopstart, len(chunks)):
             chunk = chunks[i]
             # remove all non numeric \D
-            chunk = re.sub(r"\D", self.blankfn, chunk)
+            chunk = re.sub(r"\D", "", chunk)
             if chunk == "":
                 chunk = "0"
 
@@ -3710,11 +3689,11 @@ class engine:
 
             if chunk[-2:] == ", ":
                 chunk = chunk[:-2]
-            chunk = re.sub(r"\s+,", self.commafn, chunk)
+            chunk = re.sub(r"\s+,", ",", chunk)
 
             if group == 0 and first:
                 chunk = re.sub(r", (\S+)\s+\Z", f" {andword} \\1", chunk)
-            chunk = re.sub(r"\s+", self.spacefn, chunk)
+            chunk = re.sub(r"\s+", " ", chunk)
             # chunk = re.sub(r"(\A\s|\s\Z)", self.blankfn, chunk)
             chunk = chunk.strip()
             if first:

--- a/inflect.py
+++ b/inflect.py
@@ -90,7 +90,7 @@ def print3(txt):
 
 
 def enclose(s):
-    return "(?:%s)" % s
+    return f"(?:{s})"
 
 
 def joinstem(cutpoint=0, words=""):
@@ -258,7 +258,7 @@ pl_sb_C_is_ides_endings = [
 ]
 
 pl_sb_C_is_ides = joinstem(
-    -2, pl_sb_C_is_ides_complete + [".*%s" % w for w in pl_sb_C_is_ides_endings]
+    -2, pl_sb_C_is_ides_complete + [f".*{w}" for w in pl_sb_C_is_ides_endings]
 )
 
 pl_sb_C_is_ides_list = pl_sb_C_is_ides_complete + pl_sb_C_is_ides_endings
@@ -524,14 +524,14 @@ pl_sb_C_o_i = [
 ]  # list not tuple so can concat for pl_sb_U_o_os
 
 pl_sb_C_o_i_bysize = bysize(pl_sb_C_o_i)
-si_sb_C_o_i_bysize = bysize(["%si" % w[:-1] for w in pl_sb_C_o_i])
+si_sb_C_o_i_bysize = bysize([f"{w[:-1]}i" for w in pl_sb_C_o_i])
 
 pl_sb_C_o_i_stems = joinstem(-1, pl_sb_C_o_i)
 
 # ALWAYS "..o" -> "..os"
 
 pl_sb_U_o_os_complete = {"ado", "ISO", "NATO", "NCO", "NGO", "oto"}
-si_sb_U_o_os_complete = {"%ss" % w for w in pl_sb_U_o_os_complete}
+si_sb_U_o_os_complete = {f"{w}s" for w in pl_sb_U_o_os_complete}
 
 
 pl_sb_U_o_os_endings = [
@@ -732,7 +732,7 @@ pl_sb_U_o_os_endings = [
 ] + pl_sb_C_o_i
 
 pl_sb_U_o_os_bysize = bysize(pl_sb_U_o_os_endings)
-si_sb_U_o_os_bysize = bysize(["%ss" % w for w in pl_sb_U_o_os_endings])
+si_sb_U_o_os_bysize = bysize([f"{w}s" for w in pl_sb_U_o_os_endings])
 
 
 # UNCONDITIONAL "..ch" -> "..chs"
@@ -891,7 +891,7 @@ pl_sb_uninflected_s_endings = [
 ]
 
 pl_sb_uninflected_s = pl_sb_uninflected_s_complete + [
-    ".*%s" % w for w in pl_sb_uninflected_s_endings
+    f".*{w}" for w in pl_sb_uninflected_s_endings
 ]
 
 pl_sb_uninflected_herd = (
@@ -1043,8 +1043,8 @@ pl_sb_singular_s_endings = ["ss", "us"] + pl_sb_C_is_ides_endings
 
 pl_sb_singular_s_bysize = bysize(pl_sb_singular_s_endings)
 
-si_sb_singular_s_complete = ["%ses" % w for w in pl_sb_singular_s_complete]
-si_sb_singular_s_endings = ["%ses" % w for w in pl_sb_singular_s_endings]
+si_sb_singular_s_complete = [f"{w}es" for w in pl_sb_singular_s_complete]
+si_sb_singular_s_endings = [f"{w}es" for w in pl_sb_singular_s_endings]
 si_sb_singular_s_bysize = bysize(si_sb_singular_s_endings)
 
 pl_sb_singular_s_es = ["[A-Z].*es"]
@@ -1052,7 +1052,7 @@ pl_sb_singular_s_es = ["[A-Z].*es"]
 pl_sb_singular_s = enclose(
     "|".join(
         pl_sb_singular_s_complete
-        + [".*%s" % w for w in pl_sb_singular_s_endings]
+        + [f".*{w}" for w in pl_sb_singular_s_endings]
         + pl_sb_singular_s_es
     )
 )
@@ -1454,10 +1454,7 @@ _pl_sb_postfix_adj_defn = {
 
 pl_sb_postfix_adj: Dict[str, str] = {}
 
-for key, val in _pl_sb_postfix_adj_defn.items():
-    pl_sb_postfix_adj[key] = enclose(enclose("|".join(val)) + "(?=(?:-|\\s+)%s)" % key)
-
-pl_sb_postfix_adj_stems = "(" + "|".join(list(pl_sb_postfix_adj.values())) + ")(.*)"
+pl_sb_postfix_adj_stems = f"({'|'.join(pl_sb_postfix_adj.values())})(.*)"
 
 
 # PLURAL WORDS ENDING IS es GO TO SINGULAR is
@@ -1543,9 +1540,7 @@ pl_prep_bysize = bysize(pl_prep_list_da)
 
 pl_prep = enclose("|".join(pl_prep_list_da))
 
-pl_sb_prep_dual_compound = (
-    r"(.*?)((?:-|\s+)(?:" + pl_prep + r")(?:-|\s+))a(?:-|\s+)(.*)"
-)
+pl_sb_prep_dual_compound = fr"(.*?)((?:-|\s+)(?:{pl_prep})(?:-|\s+))a(?:-|\s+)(.*)"
 
 
 singular_pronoun_genders = {
@@ -1943,9 +1938,7 @@ class engine:
 
     def __getattr__(self, meth):
         if meth in self.deprecated_methods:
-            print3(
-                "{}() deprecated, use {}()".format(meth, self.deprecated_methods[meth])
-            )
+            print3(f"{meth}() deprecated, use {self.deprecated_methods[meth]}()")
             raise DeprecationWarning
         raise AttributeError
 
@@ -2013,7 +2006,7 @@ class engine:
         try:
             re.match(pattern, "")
         except re.error:
-            print3("\nBad user-defined singular pattern:\n\t%s\n" % pattern)
+            print3(f"\nBad user-defined singular pattern:\n\t{pattern}\n")
             raise BadUserDefinedPatternError
 
     def checkpatplural(self, pattern):
@@ -2024,7 +2017,7 @@ class engine:
 
     def ud_match(self, word, wordlist):
         for i in range(len(wordlist) - 2, -2, -2):  # backwards through even elements
-            mo = re.search(r"^%s$" % wordlist[i], word, re.IGNORECASE)
+            mo = re.search(fr"^{wordlist[i]}$", word, re.IGNORECASE)
             if mo:
                 if wordlist[i + 1] is None:
                     return None
@@ -2130,7 +2123,7 @@ class engine:
         # Probably passed a variable name.
         # Or passed a single word without wrapping it in quotes as an argument
         # ex: p.inflect("I plural(see)") instead of p.inflect("I plural('see')")
-        raise NameError("name '%s' is not defined" % obj.id)
+        raise NameError(f"name '{obj.id}' is not defined")
 
     def _string_to_substitute(self, mo, methods_dict):
         """
@@ -2245,7 +2238,7 @@ class engine:
             or self._pl_special_verb(word, count)
             or self._plnoun(word, count),
         )
-        return "{}{}{}".format(pre, plural, post)
+        return f"{pre}{plural}{post}"
 
     def plural_noun(self, text, count=None):
         """
@@ -2262,7 +2255,7 @@ class engine:
         if not word:
             return text
         plural = self.postprocess(word, self._plnoun(word, count))
-        return "{}{}{}".format(pre, plural, post)
+        return f"{pre}{plural}{post}"
 
     def plural_verb(self, text, count=None):
         """
@@ -2282,7 +2275,7 @@ class engine:
             word,
             self._pl_special_verb(word, count) or self._pl_general_verb(word, count),
         )
-        return "{}{}{}".format(pre, plural, post)
+        return f"{pre}{plural}{post}"
 
     def plural_adj(self, text, count=None):
         """
@@ -2299,7 +2292,7 @@ class engine:
         if not word:
             return text
         plural = self.postprocess(word, self._pl_special_adjective(word, count) or word)
-        return "{}{}{}".format(pre, plural, post)
+        return f"{pre}{plural}{post}"
 
     def compare(self, word1, word2):
         """
@@ -2396,7 +2389,7 @@ class engine:
         sing = self._sinoun(word, count=count, gender=gender)
         if sing is not False:
             plural = self.postprocess(word, sing)
-            return "{}{}{}".format(pre, plural, post)
+            return f"{pre}{plural}{post}"
         return False
 
     def _plequal(self, word1, word2, pl):
@@ -2426,7 +2419,7 @@ class engine:
         return False
 
     def _pl_reg_plurals(self, pair, stems, end1, end2):
-        pattern = r"({})({}\|\1{}|{}\|\1{})".format(stems, end1, end2, end2, end1)
+        pattern = fr"({stems})({end1}\|\1{end2}|{end2}\|\1{end1})"
         return bool(re.search(pattern, pair))
 
     def _pl_check_plurals_N(self, word1, word2):
@@ -2531,15 +2524,17 @@ class engine:
 
         # HANDLE COMPOUNDS ("Governor General", "mother-in-law", "aide-de-camp", ETC.)
 
-        mo = re.search(r"^(?:%s)$" % pl_sb_postfix_adj_stems, word, re.IGNORECASE)
+        mo = re.search(fr"^(?:{pl_sb_postfix_adj_stems})$", word, re.IGNORECASE)
         if mo and mo.group(2) != "":
-            return "{}{}".format(self._plnoun(mo.group(1), 2), mo.group(2))
+            return f"{self._plnoun(mo.group(1), 2)}{mo.group(2)}"
 
         if " a " in word.lower or "-a-" in word.lower:
-            mo = re.search(r"^(?:%s)$" % pl_sb_prep_dual_compound, word, re.IGNORECASE)
+            mo = re.search(fr"^(?:{pl_sb_prep_dual_compound})$", word, re.IGNORECASE)
             if mo and mo.group(2) != "" and mo.group(3) != "":
-                return "{}{}{}".format(
-                    self._plnoun(mo.group(1), 2), mo.group(2), self._plnoun(mo.group(3))
+                return (
+                    f"{self._plnoun(mo.group(1), 2)}"
+                    f"{mo.group(2)}"
+                    f"{self._plnoun(mo.group(3))}"
                 )
 
         if len(word.split) >= 3:
@@ -2553,11 +2548,11 @@ class engine:
 
         # only pluralize denominators in units
         mo = re.search(
-            r"(?P<denominator>.+)( (%s) .+)" % "|".join(["per", "a"]), word.lower
+            fr"(?P<denominator>.+)( ({'|'.join(['per', 'a'])}) .+)", word.lower
         )
         if mo:
             index = len(mo.group("denominator"))
-            return "{}{}".format(self._plnoun(word[:index]), word[index:])
+            return f"{self._plnoun(word[:index])}{word[index:]}"
 
         # handle units given in degrees (only accept if
         # there is no more than one word following)
@@ -2604,52 +2599,52 @@ class engine:
 
         if word.last in list(pl_sb_irregular_caps.keys()):
             llen = len(word.last)
-            return "{}{}".format(word[:-llen], pl_sb_irregular_caps[word.last])
+            return f"{word[:-llen]}{pl_sb_irregular_caps[word.last]}"
 
         if word.last.lower() in list(pl_sb_irregular.keys()):
             llen = len(word.last.lower())
-            return "{}{}".format(word[:-llen], pl_sb_irregular[word.last.lower()])
+            return f"{word[:-llen]}{pl_sb_irregular[word.last.lower()]}"
 
         if (" ".join(word.split[-2:])).lower() in list(pl_sb_irregular_compound.keys()):
             llen = len(
                 " ".join(word.split[-2:])
             )  # TODO: what if 2 spaces between these words?
-            return "{}{}".format(
-                word[:-llen],
-                pl_sb_irregular_compound[(" ".join(word.split[-2:])).lower()],
+            return (
+                f"{word[:-llen]}"
+                f"{pl_sb_irregular_compound[(' '.join(word.split[-2:])).lower()]}"
             )
 
         if word.lower[-3:] == "quy":
-            return word[:-1] + "ies"
+            return f"{word[:-1]}ies"
 
         if word.lower[-6:] == "person":
             if self.classical_dict["persons"]:
-                return word + "s"
+                return f"{word}s"
             else:
-                return word[:-4] + "ople"
+                return f"{word[:-4]}ople"
 
         # HANDLE FAMILIES OF IRREGULAR PLURALS
 
         if word.lower[-3:] == "man":
             for k, v in pl_sb_U_man_mans_bysize.items():
                 if word.lower[-k:] in v:
-                    return word + "s"
+                    return f"{word}s"
             for k, v in pl_sb_U_man_mans_caps_bysize.items():
                 if word[-k:] in v:
-                    return word + "s"
-            return word[:-3] + "men"
+                    return f"{word}s"
+            return f"{word[:-3]}men"
         if word.lower[-5:] == "mouse":
-            return word[:-5] + "mice"
+            return f"{word[:-5]}mice"
         if word.lower[-5:] == "louse":
-            return word[:-5] + "lice"
+            return f"{word[:-5]}lice"
         if word.lower[-5:] == "goose":
-            return word[:-5] + "geese"
+            return f"{word[:-5]}geese"
         if word.lower[-5:] == "tooth":
-            return word[:-5] + "teeth"
+            return f"{word[:-5]}teeth"
         if word.lower[-4:] == "foot":
-            return word[:-4] + "feet"
+            return f"{word[:-4]}feet"
         if word.lower[-4:] == "taco":
-            return word[:-5] + "tacos"
+            return f"{word[:-5]}tacos"
 
         if word.lower == "die":
             return "dice"
@@ -2659,9 +2654,9 @@ class engine:
         if word.lower[-4:] == "ceps":
             return word
         if word.lower[-4:] == "zoon":
-            return word[:-2] + "a"
+            return f"{word[:-2]}a"
         if word.lower[-3:] in ("cis", "sis", "xis"):
-            return word[:-2] + "es"
+            return f"{word[:-2]}es"
 
         for lastlet, d, numend, post in (
             ("h", pl_sb_U_ch_chs_bysize, None, "s"),
@@ -2681,11 +2676,11 @@ class engine:
 
         if self.classical_dict["ancient"]:
             if word.lower[-4:] == "trix":
-                return word[:-1] + "ces"
+                return f"{word[:-1]}ces"
             if word.lower[-3:] in ("eau", "ieu"):
-                return word + "x"
+                return f"{word}x"
             if word.lower[-3:] in ("ynx", "inx", "anx") and len(word) > 4:
-                return word[:-1] + "ges"
+                return f"{word[:-1]}ges"
 
             for lastlet, d, numend, post in (
                 ("n", pl_sb_C_en_ina_bysize, -2, "ina"),
@@ -2716,72 +2711,72 @@ class engine:
         # HANDLE SINGULAR NOUNS ENDING IN ...s OR OTHER SILIBANTS
 
         if word.last.lower() in pl_sb_singular_s_complete:
-            return word + "es"
+            return f"{word}es"
 
         for k, v in pl_sb_singular_s_bysize.items():
             if word.lower[-k:] in v:
-                return word + "es"
+                return f"{word}es"
 
         if word.lower[-2:] == "es" and word[0] == word[0].upper():
-            return word + "es"
+            return f"{word}es"
 
         if word.lower[-1] == "z":
             for k, v in pl_sb_z_zes_bysize.items():
                 if word.lower[-k:] in v:
-                    return word + "es"
+                    return f"{word}es"
 
             if word.lower[-2:-1] != "z":
-                return word + "zes"
+                return f"{word}zes"
 
         if word.lower[-2:] == "ze":
             for k, v in pl_sb_ze_zes_bysize.items():
                 if word.lower[-k:] in v:
-                    return word + "s"
+                    return f"{word}s"
 
         if word.lower[-2:] in ("ch", "sh", "zz", "ss") or word.lower[-1] == "x":
-            return word + "es"
+            return f"{word}es"
 
         # HANDLE ...f -> ...ves
 
         if word.lower[-3:] in ("elf", "alf", "olf"):
-            return word[:-1] + "ves"
+            return f"{word[:-1]}ves"
         if word.lower[-3:] == "eaf" and word.lower[-4:-3] != "d":
-            return word[:-1] + "ves"
+            return f"{word[:-1]}ves"
         if word.lower[-4:] in ("nife", "life", "wife"):
-            return word[:-2] + "ves"
+            return f"{word[:-2]}ves"
         if word.lower[-3:] == "arf":
-            return word[:-1] + "ves"
+            return f"{word[:-1]}ves"
 
         # HANDLE ...y
 
         if word.lower[-1] == "y":
             if word.lower[-2:-1] in "aeiou" or len(word) == 1:
-                return word + "s"
+                return f"{word}s"
 
             if self.classical_dict["names"]:
                 if word.lower[-1] == "y" and word[0] == word[0].upper():
-                    return word + "s"
+                    return f"{word}s"
 
-            return word[:-1] + "ies"
+            return f"{word[:-1]}ies"
 
         # HANDLE ...o
 
         if word.last.lower() in pl_sb_U_o_os_complete:
-            return word + "s"
+            return f"{word}s"
 
         for k, v in pl_sb_U_o_os_bysize.items():
             if word.lower[-k:] in v:
-                return word + "s"
+                return f"{word}s"
 
         if word.lower[-2:] in ("ao", "eo", "io", "oo", "uo"):
-            return word + "s"
+            return f"{word}s"
 
         if word.lower[-1] == "o":
-            return word + "es"
+            return f"{word}es"
 
         # OTHERWISE JUST ADD ...s
 
-        return "%ss" % word
+        return f"{word}s"
 
     def _pl_special_verb(self, word, count=None):
         if self.classical_dict["zero"] and str(count).lower() in pl_count_zero:
@@ -2828,7 +2823,7 @@ class engine:
 
         # HANDLE SPECIAL CASES
 
-        mo = re.search(r"^(%s)$" % plverb_special_s, word)
+        mo = re.search(fr"^({plverb_special_s})$", word)
         if mo:
             return False
         if re.search(r"\s", word):
@@ -2876,17 +2871,15 @@ class engine:
         # HANDLE AMBIGUOUS PRESENT TENSES  (SIMPLE AND COMPOUND)
 
         mo = re.search(
-            r"^(%s)((\s.*)?)$" % plverb_ambiguous_pres_keys, word, re.IGNORECASE
+            fr"^({plverb_ambiguous_pres_keys})((\s.*)?)$", word, re.IGNORECASE
         )
         if mo:
-            return "{}{}".format(
-                plverb_ambiguous_pres[mo.group(1).lower()], mo.group(2)
-            )
+            return f"{plverb_ambiguous_pres[mo.group(1).lower()]}{mo.group(2)}"
 
         # HANDLE AMBIGUOUS PRETERITE AND PERFECT TENSES
 
         mo = re.search(
-            r"^(%s)((\s.*)?)$" % plverb_ambiguous_non_pres, word, re.IGNORECASE
+            fr"^({plverb_ambiguous_non_pres})((\s.*)?)$", word, re.IGNORECASE
         )
         if mo:
             return word
@@ -2909,21 +2902,21 @@ class engine:
 
         # HANDLE KNOWN CASES
 
-        mo = re.search(r"^(%s)$" % pl_adj_special_keys, word, re.IGNORECASE)
+        mo = re.search(fr"^({pl_adj_special_keys})$", word, re.IGNORECASE)
         if mo:
-            return "%s" % (pl_adj_special[mo.group(1).lower()])
+            return pl_adj_special[mo.group(1).lower()]
 
         # HANDLE POSSESSIVES
 
-        mo = re.search(r"^(%s)$" % pl_adj_poss_keys, word, re.IGNORECASE)
+        mo = re.search(fr"^({pl_adj_poss_keys})$", word, re.IGNORECASE)
         if mo:
-            return "%s" % (pl_adj_poss[mo.group(1).lower()])
+            return pl_adj_poss[mo.group(1).lower()]
 
         mo = re.search(r"^(.*)'s?$", word)
         if mo:
             pl = self.plural_noun(mo.group(1))
             trailing_s = "" if pl[-1] == "s" else "s"
-            return "{}'{}".format(pl, trailing_s)
+            return f"{pl}'{trailing_s}"
 
         # OTHERWISE, NO IDEA
 
@@ -2982,11 +2975,9 @@ class engine:
 
         # HANDLE COMPOUNDS ("Governor General", "mother-in-law", "aide-de-camp", ETC.)
 
-        mo = re.search(r"^(?:%s)$" % pl_sb_postfix_adj_stems, word, re.IGNORECASE)
+        mo = re.search(fr"^(?:{pl_sb_postfix_adj_stems})$", word, re.IGNORECASE)
         if mo and mo.group(2) != "":
-            return "{}{}".format(
-                self._sinoun(mo.group(1), 1, gender=gender), mo.group(2)
-            )
+            return f"{self._sinoun(mo.group(1), 1, gender=gender)}{mo.group(2)}"
 
         word.split = word.lower.split(" ")
         if len(word.split) >= 3:
@@ -3284,7 +3275,7 @@ class engine:
             pre = mo.group(1)
             post = mo.group(3)
             result = self._indef_article(word, count)
-            return "{}{}{}".format(pre, result, post)
+            return f"{pre}{result}{post}"
         return ""
 
     an = a
@@ -3293,48 +3284,48 @@ class engine:
         mycount = self.get_count(count)
 
         if mycount != 1:
-            return "{} {}".format(count, word)
+            return f"{count} {word}"
 
         # HANDLE USER-DEFINED VARIANTS
 
         value = self.ud_match(word, self.A_a_user_defined)
         if value is not None:
-            return "{} {}".format(value, word)
+            return f"{value} {word}"
 
         # HANDLE ORDINAL FORMS
 
-        for a in ((r"^(%s)" % A_ordinal_a, "a"), (r"^(%s)" % A_ordinal_an, "an")):
+        for a in ((fr"^({A_ordinal_a})", "a"), (fr"^({A_ordinal_an})", "an")):
             mo = re.search(a[0], word, re.IGNORECASE)
             if mo:
-                return "{} {}".format(a[1], word)
+                return f"{a[1]} {word}"
 
         # HANDLE SPECIAL CASES
 
         for a in (
-            (r"^(%s)" % A_explicit_an, "an"),
+            (fr"^({A_explicit_an})", "an"),
             (r"^[aefhilmnorsx]$", "an"),
             (r"^[bcdgjkpqtuvwyz]$", "a"),
         ):
             mo = re.search(a[0], word, re.IGNORECASE)
             if mo:
-                return "{} {}".format(a[1], word)
+                return f"{a[1]} {word}"
 
         # HANDLE ABBREVIATIONS
 
         for a in (
-            (r"(%s)" % A_abbrev, "an", re.VERBOSE),
+            (fr"({A_abbrev})", "an", re.VERBOSE),
             (r"^[aefhilmnorsx][.-]", "an", re.IGNORECASE),
             (r"^[a-z][.-]", "a", re.IGNORECASE),
         ):
             mo = re.search(a[0], word, a[2])
             if mo:
-                return "{} {}".format(a[1], word)
+                return f"{a[1]} {word}"
 
         # HANDLE CONSONANTS
 
         mo = re.search(r"^[^aeiouy]", word, re.IGNORECASE)
         if mo:
-            return "a %s" % word
+            return f"a {word}"
 
         # HANDLE SPECIAL VOWEL-FORMS
 
@@ -3345,32 +3336,32 @@ class engine:
             (r"^uni([^nmd]|mo)", "a"),
             (r"^u[bcfghjkqrst][aeiou]", "a"),
             (r"^ukr", "a"),
-            (r"^(%s)" % A_explicit_a, "a"),
+            (fr"^({A_explicit_a})", "a"),
         ):
             mo = re.search(a[0], word, re.IGNORECASE)
             if mo:
-                return "{} {}".format(a[1], word)
+                return f"{a[1]} {word}"
 
         # HANDLE SPECIAL CAPITALS
 
         mo = re.search(r"^U[NK][AIEO]?", word)
         if mo:
-            return "a %s" % word
+            return f"a {word}"
 
         # HANDLE VOWELS
 
         mo = re.search(r"^[aeiou]", word, re.IGNORECASE)
         if mo:
-            return "an %s" % word
+            return f"an {word}"
 
         # HANDLE y... (BEFORE CERTAIN CONSONANTS IMPLIES (UNNATURALIZED) "i.." SOUND)
 
-        mo = re.search(r"^(%s)" % A_y_cons, word, re.IGNORECASE)
+        mo = re.search(fr"^({A_y_cons})", word, re.IGNORECASE)
         if mo:
-            return "an %s" % word
+            return f"an {word}"
 
         # OTHERWISE, GUESS "a"
-        return "a %s" % word
+        return f"a {word}"
 
     # 2. TRANSLATE ZERO-QUANTIFIED $word TO "no plural($word)"
 
@@ -3402,7 +3393,7 @@ class engine:
 
         if str(count).lower() in pl_count_zero:
             count = 'no'
-        return "{}{} {}{}".format(pre, count, self.plural(word, count), post)
+        return f"{pre}{count} {self.plural(word, count)}{post}"
 
     # PARTICIPLES
 
@@ -3430,8 +3421,8 @@ class engine:
         ):
             (ans, num) = re.subn(pat, repl, plv)
             if num:
-                return "%sing" % ans
-        return "%sing" % ans
+                return f"{ans}ing"
+        return f"{ans}ing"
 
     # NUMERICAL INFLECTIONS
 
@@ -3464,14 +3455,14 @@ class engine:
                 post = nth[n % 100]
             except KeyError:
                 post = nth[n % 10]
-            return "{}{}".format(num, post)
+            return f"{num}{post}"
         else:
-            mo = re.search(r"(%s)\Z" % ordinal_suff, num)
+            mo = re.search(fr"({ordinal_suff})\Z", num)
             try:
                 post = ordinal[mo.group(1)]
-                return re.sub(r"(%s)\Z" % ordinal_suff, post, num)
+                return re.sub(fr"({ordinal_suff})\Z", post, num)
             except AttributeError:
-                return "%sth" % num
+                return f"{num}th"
 
     def millfn(self, ind=0):
         if ind > len(mill) - 1:
@@ -3480,75 +3471,74 @@ class engine:
         return mill[ind]
 
     def unitfn(self, units, mindex=0):
-        return "{}{}".format(unit[units], self.millfn(mindex))
+        return f"{unit[units]}{self.millfn(mindex)}"
 
     def tenfn(self, tens, units, mindex=0):
         if tens != 1:
-            return "{}{}{}{}".format(
-                ten[tens],
-                "-" if tens and units else "",
-                unit[units],
-                self.millfn(mindex),
-            )
-        return "{}{}".format(teen[units], mill[mindex])
+            tens_part = ten[tens]
+            if tens and units:
+                hyphen = "-"
+            else:
+                hyphen = ""
+            unit_part = unit[units]
+            mill_part = self.millfn(mindex)
+            return f"{tens_part}{hyphen}{unit_part}{mill_part}"
+        return f"{teen[units]}{mill[mindex]}"
 
     def hundfn(self, hundreds, tens, units, mindex):
         if hundreds:
-            andword = " %s " % self.number_args["andword"] if tens or units else ""
-            return "{} hundred{}{}{}, ".format(
-                unit[hundreds],  # use unit not unitfn as simpler
-                andword,
-                self.tenfn(tens, units),
-                self.millfn(mindex),
+            andword = f" {self.number_args['andword']} " if tens or units else ""
+            # use unit not unitfn as simpler
+            return (
+                f"{unit[hundreds]} hundred{andword}"
+                f"{self.tenfn(tens, units)}{self.millfn(mindex)}, "
             )
         if tens or units:
-            return "{}{}, ".format(self.tenfn(tens, units), self.millfn(mindex))
+            return f"{self.tenfn(tens, units)}{self.millfn(mindex)}, "
         return ""
 
     def group1sub(self, mo):
         units = int(mo.group(1))
         if units == 1:
-            return " %s, " % self.number_args["one"]
+            return f" {self.number_args['one']}, "
         elif units:
-            return "%s, " % unit[units]
+            return f"{unit[units]}, "
         else:
-            return " %s, " % self.number_args["zero"]
+            return f" {self.number_args['zero']}, "
 
     def group1bsub(self, mo):
         units = int(mo.group(1))
         if units:
-            return "%s, " % unit[units]
+            return f"{unit[units]}, "
         else:
-            return " %s, " % self.number_args["zero"]
+            return f" {self.number_args['zero']}, "
 
     def group2sub(self, mo):
         tens = int(mo.group(1))
         units = int(mo.group(2))
         if tens:
-            return "%s, " % self.tenfn(tens, units)
+            return f"{self.tenfn(tens, units)}, "
         if units:
-            return " {} {}, ".format(self.number_args["zero"], unit[units])
-        return " {} {}, ".format(self.number_args["zero"], self.number_args["zero"])
+            return f" {self.number_args['zero']} {unit[units]}, "
+        return f" {self.number_args['zero']} {self.number_args['zero']}, "
 
     def group3sub(self, mo):
         hundreds = int(mo.group(1))
         tens = int(mo.group(2))
         units = int(mo.group(3))
         if hundreds == 1:
-            hunword = " %s" % self.number_args["one"]
+            hunword = f" {self.number_args['one']}"
         elif hundreds:
-            hunword = "%s" % unit[hundreds]
+            hunword = str(unit[hundreds])
         else:
-            hunword = " %s" % self.number_args["zero"]
+            hunword = f" {self.number_args['zero']}"
         if tens:
             tenword = self.tenfn(tens, units)
         elif units:
-            tenword = " {} {}".format(self.number_args["zero"], unit[units])
+            tenword = f" {self.number_args['zero']} {unit[units]}"
         else:
-            tenword = " {} {}".format(
-                self.number_args["zero"], self.number_args["zero"]
-            )
-        return "{} {}, ".format(hunword, tenword)
+            tenword = f" {self.number_args['zero']} {self.number_args['zero']}"
+        return f"{hunword} {tenword}, "
 
     def hundsub(self, mo):
         ret = self.hundfn(
@@ -3558,10 +3548,10 @@ class engine:
         return ret
 
     def tensub(self, mo):
-        return "%s, " % self.tenfn(int(mo.group(1)), int(mo.group(2)), self.mill_count)
+        return f"{self.tenfn(int(mo.group(1)), int(mo.group(2)), self.mill_count)}, "
 
     def unitsub(self, mo):
-        return "%s, " % self.unitfn(int(mo.group(1)), self.mill_count)
+        return f"{self.unitfn(int(mo.group(1)), self.mill_count)}, "
 
     def enword(self, num, group):
         # import pdb
@@ -3640,7 +3630,7 @@ class engine:
         parameters not remembered from last call. Departure from Perl version.
         """
         self.number_args = dict(andword=andword, zero=zero, one=one)
-        num = "%s" % num
+        num = str(num)
 
         # Handle "stylistic" conversions (up to a given threshold)...
         if threshold is not None and float(num) > threshold:
@@ -3650,9 +3640,9 @@ class engine:
                 if n == 0:
                     break
             try:
-                return "{}.{}".format(spnum[0], spnum[1])
+                return f"{spnum[0]}.{spnum[1]}"
             except IndexError:
-                return "%s" % spnum[0]
+                return str(spnum[0])
 
         if group < 0 or group > 3:
             raise BadChunkingOptionError
@@ -3704,7 +3694,7 @@ class engine:
             chunk = re.sub(r"\s+,", self.commafn, chunk)
 
             if group == 0 and first:
-                chunk = re.sub(r", (\S+)\s+\Z", " %s \\1" % andword, chunk)
+                chunk = re.sub(r", (\S+)\s+\Z", f" {andword} \\1", chunk)
             chunk = re.sub(r"\s+", self.spacefn, chunk)
             # chunk = re.sub(r"(\A\s|\s\Z)", self.blankfn, chunk)
             chunk = chunk.strip()
@@ -3714,21 +3704,21 @@ class engine:
 
         numchunks = []
         if first != 0:
-            numchunks = chunks[0].split("%s " % comma)
+            numchunks = chunks[0].split(f"{comma} ")
 
         if myord and numchunks:
             # TODO: can this be just one re as it is in perl?
-            mo = re.search(r"(%s)\Z" % ordinal_suff, numchunks[-1])
+            mo = re.search(fr"({ordinal_suff})\Z", numchunks[-1])
             if mo:
                 numchunks[-1] = re.sub(
-                    r"(%s)\Z" % ordinal_suff, ordinal[mo.group(1)], numchunks[-1]
+                    fr"({ordinal_suff})\Z", ordinal[mo.group(1)], numchunks[-1]
                 )
             else:
                 numchunks[-1] += "th"
 
         for chunk in chunks[1:]:
             numchunks.append(decimal)
-            numchunks.extend(chunk.split("%s " % comma))
+            numchunks.extend(chunk.split(f"{comma} "))
 
         if finalpoint:
             numchunks.append(decimal)
@@ -3739,23 +3729,23 @@ class engine:
                 numchunks = [sign] + numchunks
             return numchunks
         elif group:
-            signout = "%s " % sign if sign else ""
-            return "{}{}".format(signout, ", ".join(numchunks))
+            signout = f"{sign} " if sign else ""
+            return f"{signout}{', '.join(numchunks)}"
         else:
-            signout = "%s " % sign if sign else ""
-            num = "{}{}".format(signout, numchunks.pop(0))
+            signout = f"{sign} " if sign else ""
+            num = f"{signout}{numchunks.pop(0)}"
             if decimal is None:
                 first = True
             else:
                 first = not num.endswith(decimal)
             for nc in numchunks:
                 if nc == decimal:
-                    num += " %s" % nc
+                    num += f" {nc}"
                     first = 0
                 elif first:
-                    num += "{} {}".format(comma, nc)
+                    num += f"{comma} {nc}"
                 else:
-                    num += " %s" % nc
+                    num += f" {nc}"
             return num
 
     # Join words with commas and a trailing 'and' (when appropriate)...
@@ -3790,10 +3780,10 @@ class engine:
             if conj == "":
                 conj = " "
             else:
-                conj = " %s " % conj
+                conj = f" {conj} "
 
         if len(words) == 2:
-            return "{}{}{}".format(words[0], conj, words[1])
+            return f"{words[0]}{conj}{words[1]}"
 
         if sep is None:
             if "," in "".join(words):
@@ -3803,9 +3793,9 @@ class engine:
         if final_sep is None:
             final_sep = sep
 
-        final_sep = "{}{}".format(final_sep, conj)
+        final_sep = f"{final_sep}{conj}"
 
         if sep_spaced:
             sep += " "
 
-        return "{}{}{}".format(sep.join(words[0:-1]), final_sep, words[-1])
+        return f"{sep.join(words[0:-1])}{final_sep}{words[-1]}"

--- a/inflect.py
+++ b/inflect.py
@@ -1451,18 +1451,17 @@ plverb_special_s = enclose(
     )
 )
 
-_pl_sb_postfix_adj_defn = {
-    "general": [r"(?!major|lieutenant|brigadier|adjutant|.*star)\S+"],
-    "martial": ["court"],
-    "force": ["pound"],
-}
+_pl_sb_postfix_adj_defn = (
+    ("general", enclose(r"(?!major|lieutenant|brigadier|adjutant|.*star)\S+")),
+    ("martial", enclose("court")),
+    ("force", enclose("pound")),
+)
 
-pl_sb_postfix_adj: Dict[str, str] = {
-    key: enclose(enclose("|".join(val)) + f"(?=(?:-|\\s+){key})")
-    for key, val in _pl_sb_postfix_adj_defn.items()
-}
+pl_sb_postfix_adj: Iterable[str] = (
+    enclose(val + f"(?=(?:-|\\s+){key})") for key, val in _pl_sb_postfix_adj_defn
+)
 
-pl_sb_postfix_adj_stems = f"({'|'.join(pl_sb_postfix_adj.values())})(.*)"
+pl_sb_postfix_adj_stems = f"({'|'.join(pl_sb_postfix_adj)})(.*)"
 
 
 # PLURAL WORDS ENDING IS es GO TO SINGULAR is
@@ -1583,8 +1582,9 @@ pl_pron_nom = {
     "theirs": "theirs",
 }
 
-si_pron: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {}
-si_pron["nom"] = {v: k for (k, v) in pl_pron_nom.items()}
+si_pron: Dict[str, Dict[str, Union[str, Dict[str, str]]]] = {
+    "nom": {v: k for (k, v) in pl_pron_nom.items()}
+}
 si_pron["nom"]["we"] = "I"
 
 

--- a/tests/test_an.py
+++ b/tests/test_an.py
@@ -18,3 +18,4 @@ def test_an():
     assert p.an("Unabomber") == "a Unabomber"
     assert p.an("unanimous decision") == "a unanimous decision"
     assert p.an("US farmer") == "a US farmer"
+    assert p.an("wild PIKACHU appeared") == "a wild PIKACHU appeared"

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -897,7 +897,7 @@ class test(unittest.TestCase):
     def test_hundfn(self):
         p = inflect.engine()
         hundfn = p.hundfn
-        p.number_args = dict(andword="and")
+        p._number_args = dict(andword="and")
         self.assertEqual(hundfn(4, 3, 1, 2), "four hundred and thirty-one  million, ")
         self.assertEqual(hundfn(4, 0, 0, 2), "four hundred  million, ")
         self.assertEqual(hundfn(4, 0, 5, 2), "four hundred and five  million, ")
@@ -908,7 +908,7 @@ class test(unittest.TestCase):
         p = inflect.engine()
         enword = p.enword
         self.assertEqual(enword("5", 1), "five, ")
-        p.number_args = dict(zero="zero", one="one", andword="and")
+        p._number_args = dict(zero="zero", one="one", andword="and")
         self.assertEqual(enword("0", 1), " zero, ")
         self.assertEqual(enword("1", 1), " one, ")
         self.assertEqual(enword("347", 1), "three, four, seven, ")
@@ -917,12 +917,12 @@ class test(unittest.TestCase):
         self.assertEqual(enword("347", 2), "thirty-four , seven, ")
         self.assertEqual(enword("34768", 2), "thirty-four , seventy-six , eight, ")
         self.assertEqual(enword("1", 2), "one, ")
-        p.number_args["one"] = "single"
+        p._number_args["one"] = "single"
         self.TODO(
             enword("1", 2), "single, ", "one, "
         )  # TODO: doesn't use default word for 'one' here
 
-        p.number_args["one"] = "one"
+        p._number_args["one"] = "one"
 
         self.assertEqual(enword("134", 3), " one thirty-four , ")
 


### PR DESCRIPTION
This is a big, invasive PR, so I am sure you will have some feedback. Some hilights:

- Use fstrings. The library supports 3.6, they definitely clean up a lot of the code, and there's some micro perf advantages to them.
- "Iterate over dict objects directly" - it looks like this code has been around the block a bit, originally written in Perl, ported to Python 2, and then to Python 3. There was a bunch of places where dictionaries were explicitly iterated over as dict.keys(), switch that back to iterating over the dictionary directly. There were also a handful of places where keys() were being unnecessarily unpacked into list(), turning an O(1) lookup into an unnecessary O(n) one!
- Added PEP484 type signatures to the library.
- Removed the Words() class, because:
  - the weird way in which it was subclassing str was busting type checking, and fixing that was basically redoing the class
  - with only four properties and no methods, it doesn't really rise to the occasion of its own class
  - While working through the conversion, I found that the author was at times confusingly clobbering the contents of the words object. Only a careful third party would pick up on this, and using separate variables for separate values is vastly more readable.
  - The class wasn't really doing its job great. The author clearly meant this to cache some frequently-used transformations, but this left him reluctant to add more than the original four transformations to the class. By tearing apart the class and just using local variables in scope I was able to pick up some more places that could re-use string modifications.
- Moved all the constant regular expressions to module-level constants. I am aware of the re module's regular expression cache but with 59 regexes that are eligible for compilation I'd expect a library to be a good citizen of the regex cache and not use it too much. There is also the perf gain from reusing the regex objects.