### PR TITLE
Support open compound nouns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v5.3.0
+======
+
+* #108: Add support for pluralizing open compound nouns.
+
 v5.2.0
 ======
 

--- a/inflect.py
+++ b/inflect.py
@@ -2285,11 +2285,22 @@ class engine:
 
     def postprocess(self, orig: str, inflected) -> str:
         inflected = str(inflected)
-        result = inflected.split(" ")
+        if "|" in inflected:
+            word_options = inflected.split("|")
+            # When two parts of a noun need to be pluralized
+            if len(word_options[0].split(" ")) == len(word_options[1].split(" ")):
+                result = inflected.split("|")[self.classical_dict["all"]].split(" ")
+            # When only the last part of the noun needs to be pluralized
+            else:
+                result = inflected.split(" ")
+                for index, word in enumerate(result):
+                    if "|" in word:
+                        result[index] = word.split("|")[self.classical_dict["all"]]
+        else:
+            result = inflected.split(" ")
+
         # Try to fix word wise capitalization
-        for index, word in enumerate(result):
-            if "|" in word:
-                result[index] = word.split("|")[self.classical_dict["all"]]
+        for index, word in enumerate(orig.split(" ")):
             if word == "I":
                 # Is this the only word for exceptions like this
                 # Where the original is fully capitalized

--- a/inflect.py
+++ b/inflect.py
@@ -2285,11 +2285,11 @@ class engine:
 
     def postprocess(self, orig: str, inflected) -> str:
         inflected = str(inflected)
-        if "|" in inflected:
-            inflected = inflected.split("|")[self.classical_dict["all"]]
         result = inflected.split(" ")
         # Try to fix word wise capitalization
-        for index, word in enumerate(orig.split(" ")):
+        for index, word in enumerate(result):
+            if "|" in word:
+                result[index] = word.split("|")[self.classical_dict["all"]]
             if word == "I":
                 # Is this the only word for exceptions like this
                 # Where the original is fully capitalized

--- a/tests/test_compounds.py
+++ b/tests/test_compounds.py
@@ -61,3 +61,30 @@ def test_unit_handling_combined():
     }
     for singular, plural in test_cases.items():
         assert p.plural(singular) == plural
+
+
+def test_unit_open_compound_nouns():
+    test_cases = {
+        "high school": "high schools",
+        "master genie": "master genies",
+        "MASTER genie": "MASTER genies",
+        "Blood brother": "Blood brothers",
+        "prima donna": "prima donnas",
+        "prima DONNA": "prima DONNAS"
+    }
+    for singular, plural in test_cases.items():
+        assert p.plural(singular) == plural
+
+
+def test_unit_open_compound_nouns_classical():
+    p.classical(all=True)
+    test_cases = {
+        "master genie": "master genii",
+        "MASTER genie": "MASTER genii",
+        "Blood brother": "Blood brethren",
+        "prima donna": "prime donne",
+        "prima DONNA": "prime DONNE"
+    }
+    for singular, plural in test_cases.items():
+        assert p.plural(singular) == plural
+    p.classical(all=False)

--- a/tests/test_compounds.py
+++ b/tests/test_compounds.py
@@ -70,7 +70,7 @@ def test_unit_open_compound_nouns():
         "MASTER genie": "MASTER genies",
         "Blood brother": "Blood brothers",
         "prima donna": "prima donnas",
-        "prima DONNA": "prima DONNAS"
+        "prima DONNA": "prima DONNAS",
     }
     for singular, plural in test_cases.items():
         assert p.plural(singular) == plural
@@ -83,7 +83,7 @@ def test_unit_open_compound_nouns_classical():
         "MASTER genie": "MASTER genii",
         "Blood brother": "Blood brethren",
         "prima donna": "prime donne",
-        "prima DONNA": "prime DONNE"
+        "prima DONNA": "prime DONNE",
     }
     for singular, plural in test_cases.items():
         assert p.plural(singular) == plural

--- a/tests/test_pl_si.py
+++ b/tests/test_pl_si.py
@@ -1,6 +1,6 @@
 import inflect
 
-FNAME = "words.txt"
+FNAME = "tests/words.txt"
 # FNAME = 'tests/list-of-nouns.txt'
 # FNAME = '/usr/share/dict/british-english'
 # FNAME = 'tricky.txt'

--- a/tests/test_pl_si.py
+++ b/tests/test_pl_si.py
@@ -1,6 +1,6 @@
 import inflect
 
-FNAME = "tests/words.txt"
+FNAME = "words.txt"
 # FNAME = 'tests/list-of-nouns.txt'
 # FNAME = '/usr/share/dict/british-english'
 # FNAME = 'tricky.txt'


### PR DESCRIPTION
`postprocess()` has been updated to support open/spaced compound nouns where the second word has a classical plural. The inner if-statement is required to check if both parts (e.g. "prima donna") or only the last part (e.g. "master genie") need to be pluralized. 

Closes #108