### PR TITLE
docs: Fix a few typos

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -2071,7 +2071,7 @@ class engine:
 
     def defa(self, pattern: str) -> int:
         """
-        Define the indefinate article as 'a' for words matching pattern.
+        Define the indefinite article as 'a' for words matching pattern.
 
         """
         self.checkpat(pattern)
@@ -2080,7 +2080,7 @@ class engine:
 
     def defan(self, pattern: str) -> int:
         """
-        Define the indefinate article as 'an' for words matching pattern.
+        Define the indefinite article as 'an' for words matching pattern.
 
         """
         self.checkpat(pattern)
@@ -2132,7 +2132,7 @@ class engine:
 
         By default all classical modes are off except names.
 
-        unknown value in args or key in kwargs rasies
+        unknown value in args or key in kwargs raises
         exception: UnknownClasicalModeError
 
         """
@@ -2686,7 +2686,7 @@ class engine:
         # HANDLE PRONOUNS
 
         for k, v in pl_pron_acc_keys_bysize.items():
-            if word.lower[-k:] in v:  # ends with accusivate pronoun
+            if word.lower[-k:] in v:  # ends with accusative pronoun
                 for pk, pv in pl_prep_bysize.items():
                     if word.lower[:pk] in pv:  # starts with a prep
                         if word.lower.split() == [word.lower[:pk], word.lower[-k:]]:
@@ -3122,7 +3122,7 @@ class engine:
         # HANDLE PRONOUNS
 
         for k, v in si_pron_acc_keys_bysize.items():
-            if words.lower[-k:] in v:  # ends with accusivate pronoun
+            if words.lower[-k:] in v:  # ends with accusative pronoun
                 for pk, pv in pl_prep_bysize.items():
                     if words.lower[:pk] in pv:  # starts with a prep
                         if words.lower.split() == [words.lower[:pk], words.lower[-k:]]:
@@ -3773,7 +3773,7 @@ class engine:
         if finalpoint:
             numchunks.append(decimal)
 
-        # wantlist: Perl list context. can explictly specify in Python
+        # wantlist: Perl list context. can explicitly specify in Python
         if wantlist:
             if sign:
                 numchunks = [sign] + numchunks

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -627,7 +627,7 @@ class test(unittest.TestCase):
                 p._sinoun(plur), sing, msg='p._sinoun("{}") != "{}"'.format(plur, sing)
             )
 
-        # words where forming singular is ambiguious or not attempted
+        # words where forming singular is ambiguous or not attempted
         for sing, plur in (
             ("son of a gun", "sons of guns"),
             ("son-of-a-gun", "sons-of-guns"),
@@ -1121,15 +1121,15 @@ class test(unittest.TestCase):
         )
         self.assertEqual(
             wordlist(("apple", "banana", "carrot"), conj="&"), "apple, banana, & carrot"
-        )  # TODO: want space here. Done, report updtream
+        )  # TODO: want space here. Done, report upstream
         self.assertEqual(
             wordlist(("apple", "banana", "carrot"), conj="&", conj_spaced=False),
             "apple, banana,&carrot",
-        )  # TODO: want space here. Done, report updtream
+        )  # TODO: want space here. Done, report upstream
         self.assertEqual(
             wordlist(("apple", "banana", "carrot"), conj=" &", conj_spaced=False),
             "apple, banana, &carrot",
-        )  # TODO: want space here. Done, report updtream
+        )  # TODO: want space here. Done, report upstream
 
     def test_print(self):
         inflect.STDOUT_ON = True


### PR DESCRIPTION
There are small typos in:
- inflect.py
- tests/test_pwd.py

Fixes:
- Should read `upstream` rather than `updtream`.
- Should read `indefinite` rather than `indefinate`.
- Should read `accusative` rather than `accusivate`.
- Should read `raises` rather than `rasies`.
- Should read `explicitly` rather than `explictly`.
- Should read `ambiguous` rather than `ambiguious`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md