### PR TITLE
Update handling of louse/lice plurals to treat it as the exception rather than the norm

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -204,7 +204,6 @@ pl_sb_irregular = {
     "jerry": "jerries",
     "mary": "maries",
     "talouse": "talouses",
-    "blouse": "blouses",
     "rom": "roma",
     "carmen": "carmina",
 }
@@ -2758,9 +2757,9 @@ class engine:
         if word.lower[-5:] == "mouse":
             return f"{word[:-5]}mice"
         if word.lower[-5:] == "louse":
-            for k, v in pl_sb_U_louse_lice_bysize.items():
-                if word.lower[-k:] in v:
-                    return f"{word[:-5]}lice"
+            v = pl_sb_U_louse_lice_bysize.get(len(word))
+            if v and word.lower in v:
+                return f"{word[:-5]}lice"
             return f"{word}s"
         if word.lower[-5:] == "goose":
             return f"{word[:-5]}geese"
@@ -3198,10 +3197,9 @@ class engine:
         if words.lower[-4:] == "mice":
             return word[:-4] + "mouse"
         if words.lower[-4:] == "lice":
-            print(word.lower)
-            for k, v in si_sb_U_louse_lice_bysize.items():
-                if len(word) == k and words.lower[-k:] in v:
-                    return word[:-4] + "louse"
+            v = si_sb_U_louse_lice_bysize.get(len(word))
+            if v and words.lower in v:
+                return word[:-4] + "louse"
         if words.lower[-5:] == "geese":
             return word[:-5] + "goose"
         if words.lower[-5:] == "teeth":

--- a/inflect.py
+++ b/inflect.py
@@ -846,6 +846,19 @@ pl_sb_U_man_mans_caps_list = """
     pl_sb_U_man_mans_caps_bysize,
 ) = make_pl_si_lists(pl_sb_U_man_mans_caps_list, "s", None, dojoinstem=False)
 
+# UNCONDITIONAL "..louse" -> "..lice"
+pl_sb_U_louse_lice_list = (
+    "booklouse",
+    "grapelouse",
+    "louse",
+    "woodlouse"
+)
+
+(
+    si_sb_U_louse_lice_list,
+    si_sb_U_louse_lice_bysize,
+    pl_sb_U_louse_lice_bysize,
+) = make_pl_si_lists(pl_sb_U_louse_lice_list, "lice", 5, dojoinstem=False)
 
 pl_sb_uninflected_s_complete = [
     # PAIRS OR GROUPS SUBSUMED TO A SINGULAR...
@@ -2745,7 +2758,10 @@ class engine:
         if word.lower[-5:] == "mouse":
             return f"{word[:-5]}mice"
         if word.lower[-5:] == "louse":
-            return f"{word[:-5]}lice"
+            for k, v in pl_sb_U_louse_lice_bysize.items():
+                if word.lower[-k:] in v:
+                    return f"{word[:-5]}lice"
+            return f"{word}s"
         if word.lower[-5:] == "goose":
             return f"{word[:-5]}geese"
         if word.lower[-5:] == "tooth":
@@ -3182,7 +3198,10 @@ class engine:
         if words.lower[-4:] == "mice":
             return word[:-4] + "mouse"
         if words.lower[-4:] == "lice":
-            return word[:-4] + "louse"
+            print(word.lower)
+            for k, v in si_sb_U_louse_lice_bysize.items():
+                if len(word) == k and words.lower[-k:] in v:
+                    return word[:-4] + "louse"
         if words.lower[-5:] == "geese":
             return word[:-5] + "goose"
         if words.lower[-5:] == "teeth":

--- a/tests/inflections.txt
+++ b/tests/inflections.txt
@@ -2,6 +2,7 @@
       TODO:sing              a  ->  some                           # INDEFINITE ARTICLE
       TODO:  A.C.R.O.N.Y.M.  ->  A.C.R.O.N.Y.M.s
              abscissa  ->  abscissas|abscissae
+           accomplice  ->  accomplices
              Achinese  ->  Achinese
             acropolis  ->  acropolises
                 adieu  ->  adieus|adieux
@@ -679,6 +680,7 @@
                 sinus  ->  sinuses|sinus
                  size  ->  sizes
                 sizes  ->  size                           #VERB FORM
+                slice  ->  slices
              smallpox  ->  smallpox
                 Smith  ->  Smiths
    TODO:siverb         snowshoes  ->  snowshoe


### PR DESCRIPTION
Rather than treating all words ending in lice as a plural form of louse, only perform this for actual variants of "lice". This should improve the behavior for several words like accomplice, chalice, and slice, among others.