### PR TITLE
Clarifying required Python version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ v5.4.0
 * #133: Add a ``py.typed`` file so mypy recognizes type annotations.
 * Misc fixes in #128, #134, #135, #137, #138, #139, #140, #142,
   #143, #144.
-* Require Python 3.7.
+* Require Python >= 3.7.
 
 v5.3.0
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ v5.4.0
 * #133: Add a ``py.typed`` file so mypy recognizes type annotations.
 * Misc fixes in #128, #134, #135, #137, #138, #139, #140, #142,
   #143, #144.
-* Require Python >= 3.7.
+* Require Python 3.7 or later.
 
 v5.3.0
 ======


### PR DESCRIPTION
Thanks for all of your work on this great project!

The current changelog entry stating `Require Python 3.7.` could be misunderstood to mean that this library _only_ supports Python 3.7. In this PR, I suggest clarifying that this library supports [Python >= 3.7](https://github.com/jaraco/inflect/blob/6526f705f5439dbcd02bc2347f500eab56a0373a/setup.cfg#L24).