### PR TITLE
Add remaining return annotations

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -95,7 +95,7 @@ class BadGenderError(Exception):
 STDOUT_ON = False
 
 
-def print3(txt: str):
+def print3(txt: str) -> None:
     if STDOUT_ON:
         print(txt)
 
@@ -1682,7 +1682,7 @@ si_pron_acc_keys = enclose("|".join(si_pron["acc"]))
 si_pron_acc_keys_bysize = bysize(si_pron["acc"])
 
 
-def get_si_pron(thecase, word, gender):
+def get_si_pron(thecase, word, gender) -> Union[str, Dict[str, str]]:
     try:
         sing = si_pron[thecase][word]
     except KeyError:
@@ -2112,7 +2112,7 @@ class engine:
         self.A_a_user_defined.extend((pattern, "an"))
         return 1
 
-    def checkpat(self, pattern: Optional[str]):
+    def checkpat(self, pattern: Optional[str]) -> None:
         """
         check for errors in a regex pattern
         """
@@ -2124,7 +2124,7 @@ class engine:
             print3(f"\nBad user-defined singular pattern:\n\t{pattern}\n")
             raise BadUserDefinedPatternError
 
-    def checkpatplural(self, pattern: str):
+    def checkpatplural(self, pattern: str) -> None:
         """
         check for errors in a regex replace pattern
         """
@@ -2142,7 +2142,7 @@ class engine:
                 return mo.expand(pl)
         return None
 
-    def classical(self, **kwargs):
+    def classical(self, **kwargs) -> None:
         """
         turn classical mode on and off for various categories
 
@@ -2198,7 +2198,7 @@ class engine:
             self.persistent_count = None
         return ""
 
-    def gender(self, gender: str):
+    def gender(self, gender: str) -> None:
         """
         set the gender for the singular of plural pronouns
 
@@ -3581,7 +3581,7 @@ class engine:
     def unitfn(self, units: int, mindex: int = 0) -> str:
         return f"{unit[units]}{self.millfn(mindex)}"
 
-    def tenfn(self, tens, units, mindex=0):
+    def tenfn(self, tens, units, mindex=0) -> str:
         if tens != 1:
             tens_part = ten[tens]
             if tens and units:

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2015,7 +2015,7 @@ class Words(str):
     first: str
     last: str
 
-    def __init__(self, orig):
+    def __init__(self, orig) -> None:
         self.lower = self.lower()
         self.split = self.split()
         self.first = self.split[0]
@@ -2023,7 +2023,7 @@ class Words(str):
 
 
 class engine:
-    def __init__(self):
+    def __init__(self) -> None:
 
         self.classical_dict = def_classical.copy()
         self.persistent_count = None


### PR DESCRIPTION
Most importantly, it adds `-> None:` to the `__init__` of both classes, explicitly telling type checkers that the classes are in fact typed.

Note that I didn't hint `make_pl_si_lists`, as it's return type is a nightmare, and makes mypy *very* unhappy in a lot of places.