### PR TITLE
Special case repo pluralization as repos in pl_sb_U_o_os_endings

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -701,6 +701,7 @@ pl_sb_U_o_os_endings = [
     "pueblo",
     "quarto",
     "Quito",
+    "repo",
     "rhino",
     "risotto",
     "rococo",

--- a/tests/inflections.txt
+++ b/tests/inflections.txt
@@ -625,6 +625,7 @@
                 rebus  ->  rebuses
    TODO:siverb            rehoes  ->  rehoe
              reindeer  ->  reindeer
+             repo      ->  repos
    TODO:siverb           reshoes  ->  reshoe
                 rhino  ->  rhinos
            rhinoceros  ->  rhinoceroses|rhinoceros


### PR DESCRIPTION
Prior to this change, repo was being pluralized as repoes. While
repo is an abbreviation for repository, it seems common enough that
it's worth including here.
