### PR TITLE
Clean up plural issues from #15

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v5.6.2
+======
+
+* #15: Fixes to plural edge case handling.
+
 v5.6.1
 ======
 

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -333,9 +333,9 @@ pl_sb_C_a_ata_list = (
 # UNCONDITIONAL "..a" -> "..ae"
 
 pl_sb_U_a_ae_list = (
-    "alumna", 
-    "alga", 
-    "vertebra", 
+    "alumna",
+    "alga",
+    "vertebra",
     "persona",
     "vita",
 )

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -332,7 +332,13 @@ pl_sb_C_a_ata_list = (
 
 # UNCONDITIONAL "..a" -> "..ae"
 
-pl_sb_U_a_ae_list = ("alumna", "alga", "vertebra", "persona")
+pl_sb_U_a_ae_list = (
+    "alumna", 
+    "alga", 
+    "vertebra", 
+    "persona",
+    "vita",
+)
 (
     si_sb_U_a_ae_list,
     si_sb_U_a_ae_bysize,
@@ -933,6 +939,7 @@ pl_sb_uninflected_herd = (
     "eland",
     "bison",
     "buffalo",
+    "cattle",
     "elk",
     "rhinoceros",
     "zucchini",
@@ -3160,7 +3167,7 @@ class engine:
             return word
 
         if words.last.lower() in pl_sb_C_us_us:
-            return word
+            return word if self.classical_dict["ancient"] else False
 
         # HANDLE COMPOUNDS ("Governor General", "mother-in-law", "aide-de-camp", ETC.)
 

--- a/tests/inflections.txt
+++ b/tests/inflections.txt
@@ -158,6 +158,7 @@
             Cassinese  ->  Cassinese
                   cat  ->  cats
               catfish  ->  catfish
+			   cattle  ->  cattles|cattle
                cayman  ->  caymans
              Celanese  ->  Celanese
               ceriman  ->  cerimans
@@ -809,6 +810,7 @@
            Vietnamese  ->  Vietnamese
              virtuoso  ->  virtuosos|virtuosi
                 virus  ->  viruses
+				 vita  ->  vitae
                 vixen  ->  vixens
                vortex  ->  vortexes|vortices
                walrus  ->  walruses

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -318,7 +318,6 @@ class test(unittest.TestCase):
         for sing, plur in (
             ("cat", "cats"),
             ("die", "dice"),
-            ("hiatus", "hiatus"),
             ("goose", "geese"),
         ):
             self.assertEqual(p.singular_noun(plur), sing)
@@ -344,6 +343,7 @@ class test(unittest.TestCase):
         self.assertEqual(p.singular_noun("weaves"), "weave")
         
         self.assertEqual(p.singular_noun("status"), False)
+        self.assertEqual(p.singular_noun("hiatus"), False)
 
     def test_gender(self):
         p = inflect.engine()

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -318,7 +318,6 @@ class test(unittest.TestCase):
         for sing, plur in (
             ("cat", "cats"),
             ("die", "dice"),
-            ("status", "status"),
             ("hiatus", "hiatus"),
             ("goose", "geese"),
         ):
@@ -343,6 +342,8 @@ class test(unittest.TestCase):
 
         self.assertEqual(p.singular_noun("Clives"), "Clive")
         self.assertEqual(p.singular_noun("weaves"), "weave")
+        
+        self.assertEqual(p.singular_noun("status"), False)
 
     def test_gender(self):
         p = inflect.engine()

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -341,7 +341,7 @@ class test(unittest.TestCase):
 
         self.assertEqual(p.singular_noun("Clives"), "Clive")
         self.assertEqual(p.singular_noun("weaves"), "weave")
-        
+
         self.assertEqual(p.singular_noun("status"), False)
         self.assertEqual(p.singular_noun("hiatus"), False)
 


### PR DESCRIPTION
Most of the issues in #15 have already been resolved through the years, but a few remained. This PR addresses what I identified:
* Plural of `vita` should always be `vitae`.
* In classical mode, plural of `cattle` should be `cattle`.
* Outside classical mode, `status` et al. should be definitely singular rather than uninflected.