### PR TITLE
Validate words in compare()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+v5.7.0
+======
+
+* #157: ``compare`` methods now validate their inputs
+  and will raise a more meaningful exception if an
+  empty string or None is passed. This expectation is now
+  documented.
+
 v5.6.2
 ======
 

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2466,7 +2466,9 @@ class engine:
         >>> compare('egg', '')  # #157: # doctest: +SKIP
         Traceback (most recent call last):
         ...
-        ValueError: empty words not allowed
+        pydantic.error_wrappers.ValidationError: 1 validation error for Compare
+        word2
+          ensure this value has at least 1 characters...
         """
         norms = self.plural_noun, self.plural_verb, self.plural_adj
         results = (self._plequal(word1, word2, norm) for norm in norms)

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2455,6 +2455,18 @@ class engine:
         p:p - word1 and word2 are two different plural forms of the one word
         False - otherwise
 
+        >>> compare = engine().compare
+        >>> compare("egg", "eggs")
+        's:p'
+        >>> compare('egg', 'egg')
+        'eq'
+
+        Words should not be empty.
+
+        >>> compare('egg', '')  # #157: # doctest: +SKIP
+        Traceback (most recent call last):
+        ...
+        ValueError: empty words not allowed
         """
         norms = self.plural_noun, self.plural_verb, self.plural_adj
         results = (self._plequal(word1, word2, norm) for norm in norms)

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2482,7 +2482,8 @@ class engine:
         results = (self._plequal(word1, word2, norm) for norm in norms)
         return next(filter(None, results), False)
 
-    def compare_nouns(self, word1: str, word2: str) -> Union[str, bool]:
+    @validate_arguments
+    def compare_nouns(self, word1: Word, word2: Word) -> Union[str, bool]:
         """
         compare word1 and word2 for equality regardless of plurality
         word1 and word2 are to be treated as nouns
@@ -2497,7 +2498,8 @@ class engine:
         """
         return self._plequal(word1, word2, self.plural_noun)
 
-    def compare_verbs(self, word1: str, word2: str) -> Union[str, bool]:
+    @validate_arguments
+    def compare_verbs(self, word1: Word, word2: Word) -> Union[str, bool]:
         """
         compare word1 and word2 for equality regardless of plurality
         word1 and word2 are to be treated as verbs
@@ -2512,7 +2514,8 @@ class engine:
         """
         return self._plequal(word1, word2, self.plural_verb)
 
-    def compare_adjs(self, word1: str, word2: str) -> Union[str, bool]:
+    @validate_arguments
+    def compare_adjs(self, word1: Word, word2: Word) -> Union[str, bool]:
         """
         compare word1 and word2 for equality regardless of plurality
         word1 and word2 are to be treated as adjectives

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -67,6 +67,10 @@ from typing import (
 )
 
 
+from pydantic import Field, validate_arguments
+from pydantic.typing import Annotated
+
+
 class UnknownClassicalModeError(Exception):
     pass
 
@@ -2033,6 +2037,9 @@ class Words(str):
         self.last = self.split_[-1]
 
 
+Word = Annotated[str, Field(min_length=1)]
+
+
 class engine:
     def __init__(self) -> None:
 
@@ -2444,7 +2451,8 @@ class engine:
         plural = self.postprocess(word, self._pl_special_adjective(word, count) or word)
         return f"{pre}{plural}{post}"
 
-    def compare(self, word1: str, word2: str) -> Union[str, bool]:
+    @validate_arguments
+    def compare(self, word1: Word, word2: Word) -> Union[str, bool]:
         """
         compare word1 and word2 for equality regardless of plurality
 
@@ -2463,7 +2471,7 @@ class engine:
 
         Words should not be empty.
 
-        >>> compare('egg', '')  # #157: # doctest: +SKIP
+        >>> compare('egg', '')
         Traceback (most recent call last):
         ...
         pydantic.error_wrappers.ValidationError: 1 validation error for Compare

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ packages = find_namespace:
 include_package_data = true
 python_requires = >=3.7
 install_requires =
+	pydantic
 keywords = plural inflect participle
 
 [options.packages.find]


### PR DESCRIPTION
- Add doc test capturing expectation when an empty word is passed. Ref #157.
- Expected error is a pydantic ValidationError
- Define a word as a string of one or more characters and validate that assumption in .compare. Fixes #157.
