### PR TITLE
Change the parameter for gender in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ SYNOPSIS
     # SELECT THE GENDER OF SINGULAR PRONOUNS
 
     print(p.singular_noun("they"))  # 'it'
-    p.gender("f")
+    p.gender("feminine")
     print(p.singular_noun("they"))  # 'she'
 
 


### PR DESCRIPTION
Running `p.gender("f")` will raise an error, but using `p.gender("feminine")` works