### PR TITLE
Test coverage: ordinals for real numbers

### DIFF
--- a/tests/test_inflections.py
+++ b/tests/test_inflections.py
@@ -184,6 +184,13 @@ def test_ordinal():
     assert p.ordinal("one hundred and four") == "one hundred and fourth"
 
 
+@pytest.mark.xfail(reason="Uncertainty about whether non-integers can be ordinal")
+def test_decimal_ordinals():
+    p = inflect.engine()
+    assert p.ordinal("1.23") == "1.23rd"
+    assert p.ordinal("7.09") == "7.09th"
+
+
 def test_prespart():
     p = inflect.engine()
     assert p.present_participle("sees") == "seeing"


### PR DESCRIPTION
Follows-on from some code inspection in #174 (and [this related discussion](https://github.com/jaraco/inflect/commit/79fc941d5b8d3c61e51c20e8fb14221b225dc482#r103685305)).

The `inflect` library does support production of ordinals for non-integer numbers currently, so for refactor-safety, that'd seem worthwhile to add coverage for.

However, at the same time: it seems unclear to me whether ordinals make sense for non-integers.  So the test coverage is marked as `xfail` using `pytest` (it currently passes and produces an `xpass` result.  it would not fail the build but would still be noticeable in report output if the test began to fail).