### PR TITLE
Fix support for 'an'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v6.0.3
+======
+
+* #136: A/an support now more correctly honors leading
+  capitalized words and abbreviations.
+
 v6.0.2
 ======
 

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -1854,7 +1854,7 @@ pl_adj_poss_keys = re.compile(fr"^({enclose('|'.join(pl_adj_poss))})$", re.IGNOR
 
 A_abbrev = re.compile(
     r"""
-(?! FJO | [HLMNS]Y.  | RY[EO] | SQU
+^(?! FJO | [HLMNS]Y.  | RY[EO] | SQU
   | ( F[LR]? | [HL] | MN? | N | RH? | S[CHKLMNPTVW]? | X(YL)?) [AEIOU])
 [FHLMNRSX][A-Z]
 """,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 norecursedirs=dist build .tox .eggs
 addopts=--doctest-modules
-doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 filterwarnings=
 	# Ensure ResourceWarnings are emitted
 	default::ResourceWarning

--- a/tests/test_an.py
+++ b/tests/test_an.py
@@ -19,3 +19,12 @@ def test_an():
     assert p.an("unanimous decision") == "a unanimous decision"
     assert p.an("US farmer") == "a US farmer"
     assert p.an("wild PIKACHU appeared") == "a wild PIKACHU appeared"
+
+
+@__import__('pytest').mark.xfail(reason="#136")
+def test_an_abbreviation():
+    p = inflect.engine()
+
+    assert p.an("YAML code block") == "a YAML code block"
+    assert p.an("Core ML function") == "a Core ML function"
+    assert p.an("JSON code block") == "a JSON code block"

--- a/tests/test_an.py
+++ b/tests/test_an.py
@@ -21,7 +21,6 @@ def test_an():
     assert p.an("wild PIKACHU appeared") == "a wild PIKACHU appeared"
 
 
-@__import__('pytest').mark.xfail(reason="#136")
 def test_an_abbreviation():
     p = inflect.engine()
 


### PR DESCRIPTION
- fix a/an issue 136 as indicated by tonywu7
- Add test capturing missed expectation in leading abbreviations. Ref #136.

Fixes #136.