### PR TITLE
Fix ImportError in pydantic v2

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -74,7 +74,7 @@ from numbers import Number
 
 
 from pydantic import Field, validate_arguments
-from pydantic.typing import Annotated
+from typing import Annotated
 
 
 class UnknownClassicalModeError(Exception):


### PR DESCRIPTION
Fix cannot import name 'Annotated' from 'pydantic.typing'

Closes #187