### PR TITLE
Use typing_extensions only when needed

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -68,6 +68,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Match,
     Optional,
     Sequence,
@@ -78,7 +79,11 @@ from typing import (
 
 from more_itertools import windowed_complete
 from typeguard import typechecked
-from typing_extensions import Annotated, Literal
+try:
+    # Python 3.9+
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 class UnknownClassicalModeError(Exception):

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -79,11 +79,8 @@ from typing import (
 
 from more_itertools import windowed_complete
 from typeguard import typechecked
-try:
-    # Python 3.9+
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
+
+from .compat.py38 import Annotated
 
 
 class UnknownClassicalModeError(Exception):

--- a/inflect/compat/py38.py
+++ b/inflect/compat/py38.py
@@ -1,0 +1,7 @@
+import sys
+
+
+if sys.version_info > (3, 9):
+    from typing import Annotated
+else:  # pragma: no cover
+    from typing_extensions import Annotated  # noqa: F401

--- a/newsfragments/211.feature.rst
+++ b/newsfragments/211.feature.rst
@@ -1,0 +1,1 @@
+Restricted typing_extensions to Python 3.8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.8"
 dependencies = [
 	"more_itertools",
 	"typeguard >= 4.0.1",
-	"typing_extensions",
+	"typing_extensions ; python_version<'3.9'",
 ]
 keywords = [
 	"plural",


### PR DESCRIPTION
Annotated was added in Python 3.9
Literal was added in Python 3.8