### PR TITLE
chore: Make more-itertools dependency at least 8.5.0

### DIFF
--- a/newsfragments/215.bugfix.rst
+++ b/newsfragments/215.bugfix.rst
@@ -1,0 +1,1 @@
+Set minimum version of more-itertools to 8.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-	"more_itertools",
+	"more_itertools >= 8.5.0",
 	"typeguard >= 4.0.1",
 	"typing_extensions ; python_version<'3.9'",
 ]


### PR DESCRIPTION
closes #215 

Make `more-itertools` dependency to include `windowed_complete` function.