### PR TITLE
_plequal: marginally reduce cyclomatic complexity

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2572,20 +2572,16 @@ class engine:
             return f"{pre}{plural}{post}"
         return False
 
-    def _plequal(self, word1: str, word2: str, pl) -> Union[str, bool]:  # noqa: C901
+    def _plequal(self, word1: str, word2: str, pl) -> Union[str, bool]:
         classval = self.classical_dict.copy()
-        self.classical_dict = all_classical.copy()
-        if word1 == word2:
-            return "eq"
-        if word1 == pl(word2):
-            return "p:s"
-        if pl(word1) == word2:
-            return "s:p"
-        self.classical_dict = no_classical.copy()
-        if word1 == pl(word2):
-            return "p:s"
-        if pl(word1) == word2:
-            return "s:p"
+        for dictionary in (all_classical, no_classical):
+            self.classical_dict = dictionary.copy()
+            if word1 == word2:
+                return "eq"
+            if word1 == pl(word2):
+                return "p:s"
+            if pl(word1) == word2:
+                return "s:p"
         self.classical_dict = classval.copy()
 
         if pl == self.plural or pl == self.plural_noun:

--- a/tests/test_classical_all.py
+++ b/tests/test_classical_all.py
@@ -8,9 +8,9 @@ class Test:
         # DEFAULT...
 
         assert p.plural_noun("error", 0) == "errors", "classical 'zero' not active"
-        assert (
-            p.plural_noun("wildebeest") == "wildebeests"
-        ), "classical 'herd' not active"
+        assert p.plural_noun("wildebeest") == "wildebeests", (
+            "classical 'herd' not active"
+        )
         assert p.plural_noun("Sally") == "Sallys", "classical 'names' active"
         assert p.plural_noun("brother") == "brothers", "classical others not active"
         assert p.plural_noun("person") == "people", "classical 'persons' not active"
@@ -30,9 +30,9 @@ class Test:
 
         p.classical(all=False)
         assert p.plural_noun("error", 0) == "errors", "classical 'zero' not active"
-        assert (
-            p.plural_noun("wildebeest") == "wildebeests"
-        ), "classical 'herd' not active"
+        assert p.plural_noun("wildebeest") == "wildebeests", (
+            "classical 'herd' not active"
+        )
         assert p.plural_noun("Sally") == "Sallies", "classical 'names' not active"
         assert p.plural_noun("brother") == "brothers", "classical others not active"
         assert p.plural_noun("person") == "people", "classical 'persons' not active"

--- a/tests/test_numwords.py
+++ b/tests/test_numwords.py
@@ -198,19 +198,19 @@ def test_array():
         ],
         [
             "123456",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-six",
+            "one hundred and twenty-three thousand, four hundred and fifty-six",
             "one, two, three, four, five, six",
             "twelve, thirty-four, fifty-six",
             "one twenty-three, four fifty-six",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-sixth",
+            "one hundred and twenty-three thousand, four hundred and fifty-sixth",
         ],
         [
             "0123456",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-six",
+            "one hundred and twenty-three thousand, four hundred and fifty-six",
             "zero, one, two, three, four, five, six",
             "zero one, twenty-three, forty-five, six",
             "zero twelve, three forty-five, six",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-sixth",
+            "one hundred and twenty-three thousand, four hundred and fifty-sixth",
         ],
         [
             "1234567",

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -262,9 +262,9 @@ class Test:
             (p.plural_adj, "cat's", "cats'"),
             (p.plural_adj, "child's", "children's"),
         ):
-            assert (
-                fn(sing) == plur
-            ), f'{fn.__name__}("{sing}") == "{fn(sing)}" != "{plur}"'
+            assert fn(sing) == plur, (
+                f'{fn.__name__}("{sing}") == "{fn(sing)}" != "{plur}"'
+            )
 
         for sing, num, plur in (
             ("cow", 1, "cow"),
@@ -341,9 +341,9 @@ class Test:
             ("to her", "to them"),
             ("to herself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         p.gender("masculine")
@@ -354,9 +354,9 @@ class Test:
             ("to him", "to them"),
             ("to himself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         p.gender("gender-neutral")
@@ -367,9 +367,9 @@ class Test:
             ("to them", "to them"),
             ("to themself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         p.gender("neuter")
@@ -380,9 +380,9 @@ class Test:
             ("to it", "to them"),
             ("to itself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         with pytest.raises(BadGenderError):
@@ -612,9 +612,9 @@ class Test:
             ("zoo", "zoos"),
             ("tomato", "tomatoes"),
         ):
-            assert (
-                p._plnoun(sing) == plur
-            ), f'p._plnoun("{sing}") == {p._plnoun(sing)} != "{plur}"'
+            assert p._plnoun(sing) == plur, (
+                f'p._plnoun("{sing}") == {p._plnoun(sing)} != "{plur}"'
+            )
 
             assert p._sinoun(plur) == sing, f'p._sinoun("{plur}") != "{sing}"'
 


### PR DESCRIPTION
This may or may not be an improvement; please feel free to close this if it does not seem valuable or more comprehensible than the existing code.

I was briefly puzzled by the seemingly-identical `if ...` conditions that currently exist [here](https://github.com/jaraco/inflect/blob/eaf1a9bb5e0425ace0b7fb6a3be4feae92725b94/inflect/__init__.py#L2608-L2611) (L2608-L2611) compared to [here](https://github.com/jaraco/inflect/blob/eaf1a9bb5e0425ace0b7fb6a3be4feae92725b94/inflect/__init__.py#L2613-L2616) -- in fact my first suggestion for a PR here was going to be to remove the second pair of those as redundant, before I ran the test suite and encountered failures.

However, in hindsight it's not all that difficult to infer that updating the instance dictionary attribute affects the logic of those functions (a little unusual perhaps because `pl` is a callable argument, not accessed via `self` to make it obviously an instance method, but it's still understandable).