### PR TITLE
engine: migrate from py3.14-removed 'ast' classes

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2264,18 +2264,12 @@ class engine:
         """
         Return the value of the ast object.
         """
-        if isinstance(obj, ast.Num):
-            return obj.n
-        elif isinstance(obj, ast.Str):
-            return obj.s
+        if isinstance(obj, ast.Constant):
+            return obj.value
         elif isinstance(obj, ast.List):
             return [self._get_value_from_ast(e) for e in obj.elts]
         elif isinstance(obj, ast.Tuple):
             return tuple([self._get_value_from_ast(e) for e in obj.elts])
-
-        # None, True and False are NameConstants in Py3.4 and above.
-        elif isinstance(obj, ast.NameConstant):
-            return obj.value
 
         # Probably passed a variable name.
         # Or passed a single word without wrapping it in quotes as an argument

--- a/tests/test_classical_all.py
+++ b/tests/test_classical_all.py
@@ -8,9 +8,9 @@ class Test:
         # DEFAULT...
 
         assert p.plural_noun("error", 0) == "errors", "classical 'zero' not active"
-        assert (
-            p.plural_noun("wildebeest") == "wildebeests"
-        ), "classical 'herd' not active"
+        assert p.plural_noun("wildebeest") == "wildebeests", (
+            "classical 'herd' not active"
+        )
         assert p.plural_noun("Sally") == "Sallys", "classical 'names' active"
         assert p.plural_noun("brother") == "brothers", "classical others not active"
         assert p.plural_noun("person") == "people", "classical 'persons' not active"
@@ -30,9 +30,9 @@ class Test:
 
         p.classical(all=False)
         assert p.plural_noun("error", 0) == "errors", "classical 'zero' not active"
-        assert (
-            p.plural_noun("wildebeest") == "wildebeests"
-        ), "classical 'herd' not active"
+        assert p.plural_noun("wildebeest") == "wildebeests", (
+            "classical 'herd' not active"
+        )
         assert p.plural_noun("Sally") == "Sallies", "classical 'names' not active"
         assert p.plural_noun("brother") == "brothers", "classical others not active"
         assert p.plural_noun("person") == "people", "classical 'persons' not active"

--- a/tests/test_numwords.py
+++ b/tests/test_numwords.py
@@ -198,19 +198,19 @@ def test_array():
         ],
         [
             "123456",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-six",
+            "one hundred and twenty-three thousand, four hundred and fifty-six",
             "one, two, three, four, five, six",
             "twelve, thirty-four, fifty-six",
             "one twenty-three, four fifty-six",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-sixth",
+            "one hundred and twenty-three thousand, four hundred and fifty-sixth",
         ],
         [
             "0123456",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-six",
+            "one hundred and twenty-three thousand, four hundred and fifty-six",
             "zero, one, two, three, four, five, six",
             "zero one, twenty-three, forty-five, six",
             "zero twelve, three forty-five, six",
-            "one hundred and twenty-three thousand, " "four hundred and fifty-sixth",
+            "one hundred and twenty-three thousand, four hundred and fifty-sixth",
         ],
         [
             "1234567",

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -262,9 +262,9 @@ class Test:
             (p.plural_adj, "cat's", "cats'"),
             (p.plural_adj, "child's", "children's"),
         ):
-            assert (
-                fn(sing) == plur
-            ), f'{fn.__name__}("{sing}") == "{fn(sing)}" != "{plur}"'
+            assert fn(sing) == plur, (
+                f'{fn.__name__}("{sing}") == "{fn(sing)}" != "{plur}"'
+            )
 
         for sing, num, plur in (
             ("cow", 1, "cow"),
@@ -341,9 +341,9 @@ class Test:
             ("to her", "to them"),
             ("to herself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         p.gender("masculine")
@@ -354,9 +354,9 @@ class Test:
             ("to him", "to them"),
             ("to himself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         p.gender("gender-neutral")
@@ -367,9 +367,9 @@ class Test:
             ("to them", "to them"),
             ("to themself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         p.gender("neuter")
@@ -380,9 +380,9 @@ class Test:
             ("to it", "to them"),
             ("to itself", "to themselves"),
         ):
-            assert (
-                p.singular_noun(plur) == sing
-            ), f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            assert p.singular_noun(plur) == sing, (
+                f"singular_noun({plur}) == {p.singular_noun(plur)} != {sing}"
+            )
             assert p.inflect("singular_noun('%s')" % plur) == sing
 
         with pytest.raises(BadGenderError):
@@ -612,9 +612,9 @@ class Test:
             ("zoo", "zoos"),
             ("tomato", "tomatoes"),
         ):
-            assert (
-                p._plnoun(sing) == plur
-            ), f'p._plnoun("{sing}") == {p._plnoun(sing)} != "{plur}"'
+            assert p._plnoun(sing) == plur, (
+                f'p._plnoun("{sing}") == {p._plnoun(sing)} != "{plur}"'
+            )
 
             assert p._sinoun(plur) == sing, f'p._sinoun("{plur}") != "{sing}"'
 


### PR DESCRIPTION
Migrate away from some `ast` classes that are removed in version 3.14 of Python, as discovered due to continuous integration test failures with prerelease/alpha versions of Py314.  The [recommended migration path](https://docs.python.org/3.14/whatsnew/3.14.html#removed), as followed here, is to replace references to them with `ast.Constant` instead.

Resolves #224.