### PR TITLE
Fix number_to_words for floats that stringify in scientific notation

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -60,6 +60,7 @@ import contextlib
 import functools
 import itertools
 import re
+from decimal import Decimal
 from numbers import Number
 from typing import (
     TYPE_CHECKING,
@@ -3824,6 +3825,22 @@ class engine:
     def _get_sign(num):
         return {'+': 'plus', '-': 'minus'}.get(num.lstrip()[0], '')
 
+    @staticmethod
+    def _normalize_number(num):
+        """
+        Return a string representation of ``num`` suitable for word conversion.
+
+        ``float`` values are routed through ``Decimal(repr(num))`` so that
+        magnitudes Python would otherwise stringify in scientific notation
+        (``str(0.000001) == '1e-06'``) are converted to fixed-point form,
+        which the parser can then process digit-by-digit. ``repr`` already
+        yields the shortest round-trip form, so values like ``0.1`` and
+        ``999.3`` round-trip without introducing binary-float artifacts. (#226)
+        """
+        if isinstance(num, float):
+            return format(Decimal(repr(num)), "f")
+        return str(num)
+
     @typechecked
     def number_to_words(  # noqa: C901
         self,
@@ -3855,7 +3872,7 @@ class engine:
         parameters not remembered from last call. Departure from Perl version.
         """
         self._number_args = {"andword": andword, "zero": zero, "one": one}
-        num = str(num)
+        num = self._normalize_number(num)
 
         # Handle "stylistic" conversions (up to a given threshold)...
         if threshold is not None and float(num) > threshold:

--- a/newsfragments/226.bugfix.rst
+++ b/newsfragments/226.bugfix.rst
@@ -1,0 +1,4 @@
+Convert ``float`` arguments with magnitudes that stringify in scientific
+notation (e.g. ``0.000001`` -> ``'1e-06'``) to fixed-point form before
+processing, so ``number_to_words(0.000001)`` no longer parses the mantissa
+and exponent as digits.

--- a/tests/test_numwords.py
+++ b/tests/test_numwords.py
@@ -396,3 +396,25 @@ def test_issue_131():
     p = inflect.engine()
     for nth_word in inflect.nth_suff:
         assert p.number_to_words(nth_word) == "zero"
+
+
+def test_issue_226_float_scientific_notation():
+    """
+    Floats whose ``str()`` representation uses scientific notation should
+    convert correctly rather than being parsed as the mantissa-and-exponent
+    digits (e.g. ``0.000001`` rendered as ``"one hundred and six"``).
+    """
+    p = inflect.engine()
+    assert p.number_to_words(0.000001) == "zero point zero zero zero zero zero one"
+    assert (
+        p.number_to_words(-0.000001)
+        == "minus zero point zero zero zero zero zero one"
+    )
+    assert p.number_to_words(0.000001) == p.number_to_words("0.000001")
+    # Common floats with exact str() forms must remain unaffected.
+    assert p.number_to_words(0.1) == "zero point one"
+    assert p.number_to_words(999.3) == (
+        "nine hundred and ninety-nine point three"
+    )
+    # Large-magnitude floats also stringify in scientific notation.
+    assert p.number_to_words(1e20) == p.number_to_words(10**20)


### PR DESCRIPTION
## Summary

Fixes #226.

When ``str(num)`` produces a string like ``'1e-06'`` (e.g. for ``0.000001``, or for floats with magnitude ``>= 1e16``), the digits of the mantissa and exponent were being parsed as the number, yielding nonsense such as ``'one hundred and six'`` for ``0.000001``.

This routes ``float`` inputs through ``Decimal(repr(num))`` and formats with ``'f'`` to obtain the exact fixed-point representation before further processing. ``repr`` already yields the shortest round-trip form Python uses, so values whose ``str`` is not in scientific notation (``0.1``, ``999.3``, ``1.5``, …) round-trip without introducing binary-float artifacts. Only the scientific-notation cases get rewritten.

The conversion lives in a small helper, ``engine._normalize_number``, with the rationale documented in its docstring (per @jaraco's review).

## Why not the prior approach

An earlier revision of this PR formatted floats with ``f"{num:.17g}"`` / ``f"{num:.17f}"``. That fixed the reported case but exposed binary-float artifacts on common inputs:

- ``0.1`` → ``'0.10000000000000001'``
- ``999.3`` → ``'999.29999999999995'`` (broke ``test_lines``)
- ``0.3`` → 17-digit garbage ending in ``'...nine nine nine nine'``

``Decimal(repr(num))`` avoids the artifacts because ``repr(0.1) == '0.1'`` exactly, while still expanding ``repr(0.000001) == '1e-06'`` to ``'0.000001'``. Same approach as #236 (closed by its author without review).

## Behavior matrix

| input | output of ``_normalize_number`` |
|---|---|
| ``0.000001`` | ``'0.000001'`` (issue fixed) |
| ``-0.000001`` | ``'-0.000001'`` |
| ``0.1`` / ``0.2`` / ``0.3`` | ``'0.1'`` / ``'0.2'`` / ``'0.3'`` (no regression) |
| ``999.3`` / ``1000.3`` | ``'999.3'`` / ``'1000.3'`` (existing tests pass) |
| ``1e20`` | ``'100000000000000000000'`` |
| ``1e-20`` | ``'0.00000000000000000001'`` (full precision) |
| ``1.0`` | ``'1.0'`` (matches ``str(1.0)``) |
| ``int`` / ``Decimal`` / ``Fraction`` / ``str`` | ``str(num)`` (unchanged path) |

## Test plan

- [x] New regression test ``tests/test_numwords.py::test_issue_226_float_scientific_notation`` covers ``0.000001``, ``-0.000001``, parity with the string form, two common floats that must remain unaffected (``0.1``, ``999.3``), and a large-magnitude (``1e20``) case. Fails on ``main``, passes after this change.
- [x] Full ``pytest tests/`` passes (208 passed, 16 xfailed, 0 failed) — including ``test_lines`` which exercises ``999.3``-style floats through the threshold path.
- [x] ``ruff check`` introduces no new errors vs ``main``.
- [x] News fragment added at ``newsfragments/226.bugfix.rst``.