### PR TITLE
Fix TypeError in singular_noun for 'pair of scissors' (#222)

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -3007,8 +3007,14 @@ class engine:
         Handles the plural and singular for compound `Words` that
         have three or more words, based on the given count.
 
+        When the candidate word is already in the requested form,
+        ``self._sinoun`` / ``self._plnoun`` returns ``False``; fall back
+        to the original word so the joined phrase remains a string. (#222)
+
         >>> engine()._handle_long_compounds(Words("pair of scissors"), 2)
         'pairs of scissors'
+        >>> engine()._handle_long_compounds(Words("pair of scissors"), 1)
+        'pair of scissors'
         >>> engine()._handle_long_compounds(Words("men beyond hills"), 1)
         'man beyond hills'
         """
@@ -3017,7 +3023,7 @@ class engine:
             " ".join(
                 itertools.chain(
                     leader,
-                    [inflection(cand, count), prep],  # type: ignore[operator]
+                    [inflection(cand, count) or cand, prep],
                     trailer,
                 )
             )

--- a/newsfragments/222.bugfix.rst
+++ b/newsfragments/222.bugfix.rst
@@ -1,0 +1,5 @@
+Fix ``TypeError`` raised by ``singular_noun`` for compound phrases ending
+in an uninflected word (e.g. ``"pair of scissors"``). When the candidate
+word is already singular, ``_sinoun`` returns ``False``; the long-compound
+handler now falls back to the original word so the joined phrase remains
+a string.

--- a/tests/test_compounds.py
+++ b/tests/test_compounds.py
@@ -19,6 +19,18 @@ def test_compound_4():
     assert p.singular_noun("case of diapers") == "case of diapers"
 
 
+def test_singular_noun_already_singular_long_compound():
+    """
+    Compound phrases routed through ``_handle_long_compounds`` whose
+    candidate word is already singular previously raised ``TypeError``
+    because ``_sinoun`` returned ``False`` and that fell into ``str.join``.
+    See https://github.com/jaraco/inflect/issues/222.
+    """
+    assert p.singular_noun("pair of scissors") == "pair of scissors"
+    # The pluralized form should still round-trip back to the singular.
+    assert p.singular_noun("pairs of scissors") == "pair of scissors"
+
+
 def test_unit_handling_degree():
     test_cases = {
         "degree celsius": "degrees celsius",


### PR DESCRIPTION
## Summary

Fixes #222.

``p.singular_noun("pair of scissors")`` was raising:

```
TypeError: sequence item 0: expected str instance, bool found
```

``singular_noun`` routes phrases ending in an "uninflected complete" word like ``"scissors"`` through ``_handle_long_compounds``, which builds the result by joining ``inflection(cand, count)`` with the surrounding parts. When the candidate word is already in the requested form (here, ``_sinoun("pair", 1)``), ``_sinoun``/``_plnoun`` returns ``False`` rather than a string. That ``False`` fell straight into ``str.join`` and raised.

The fix falls back to the original candidate word when the inflection returns ``False``:

```diff
-                    [inflection(cand, count), prep],  # type: ignore[operator]
+                    [inflection(cand, count) or cand, prep],
```

The ``# type: ignore[operator]`` suppression is no longer needed because the joined value is now always ``str``.

## Why not the previous approach

An earlier revision of this PR added a nested ``handle_irregular_plural`` helper that consulted ``pl_sb_irregular``, an extra inline conditional, and a ``for inflection_result in [inflection(cand, count)]`` clause to memoize the inflection. While reviewing, I found:

- ``"men"`` / ``"man"`` aren't members of ``pl_sb_irregular`` at all — they're handled separately via the ``"man"``/``"men"`` suffix code at lines 2823 and 3333. ``_sinoun("men", 1)`` already returned ``"man"`` correctly without the helper.
- The outer guard ``if word in pl_sb_irregular.values()`` checked against pipe-joined strings (``"chilis|chilies"``), so most variants never matched.
- The new logic surfaced a separate pre-existing bug: ``plural_noun("men at arms")`` produced ``"mens at arms"`` (because ``_plnoun("men", 2) == "mens"``).

Returning to the simpler fallback addresses #222 without those side effects.

## Addressing the prior review (thanks for the patient feedback @jaraco)

- **"This function can be put in the global scope as a helper..."** → no helper function needed; the fallback is a single ``or cand``.
- **"The ``solutions`` expression was already near its limits for complexity..."** → expression is back to its original shape, just with the ``or cand`` suffix on the inflection call.
- **"I'm worried that the call to ``inflection`` has moved..."** → the call has *not* moved; it stays inline in its original position.
- **"The removal of these tests is concerning..."** → both original doctests are restored. Added a third doctest for the ``count=1`` case which previously raised — that case now lives both as a doctest and as a regression test.
- **"We'll want to add some tests to capture the new expectation(s)."** → ``tests/test_compounds.py::test_singular_noun_already_singular_long_compound`` exercises the issue's exact reproducer and the round-trip from ``"pairs of scissors"``.

## Test plan

- [x] New regression test ``tests/test_compounds.py::test_singular_noun_already_singular_long_compound``: ``p.singular_noun("pair of scissors") == "pair of scissors"`` and ``p.singular_noun("pairs of scissors") == "pair of scissors"``. Fails on ``main``, passes after this change.
- [x] New doctest line for ``_handle_long_compounds(Words("pair of scissors"), 1)``.
- [x] Full ``pytest tests/ --doctest-modules inflect/__init__.py`` passes (215 passed, 16 xfailed, 0 failed).
- [x] ``ruff check`` introduces no new errors vs ``main``.
- [x] News fragment added at ``newsfragments/222.bugfix.rst``.