### PR TITLE
Fix number_to_words for floats in scientific notation

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -60,6 +60,7 @@ import contextlib
 import functools
 import itertools
 import re
+from decimal import Decimal as _Decimal
 from numbers import Number
 from typing import (
     TYPE_CHECKING,
@@ -3855,7 +3856,10 @@ class engine:
         parameters not remembered from last call. Departure from Perl version.
         """
         self._number_args = {"andword": andword, "zero": zero, "one": one}
-        num = str(num)
+        if isinstance(num, float):
+            num = format(_Decimal(repr(num)), "f")
+        else:
+            num = str(num)
 
         # Handle "stylistic" conversions (up to a given threshold)...
         if threshold is not None and float(num) > threshold:

--- a/tests/test_numwords.py
+++ b/tests/test_numwords.py
@@ -396,3 +396,19 @@ def test_issue_131():
     p = inflect.engine()
     for nth_word in inflect.nth_suff:
         assert p.number_to_words(nth_word) == "zero"
+
+
+def test_float_scientific_notation():
+    """Float values in scientific notation should be converted correctly."""
+    p = inflect.engine()
+    assert p.number_to_words(0.000001) == "zero point zero zero zero zero zero one"
+    assert (
+        p.number_to_words(1e-10)
+        == "zero point zero zero zero zero zero zero zero zero zero one"
+    )
+    assert p.number_to_words(0.1) == "zero point one"
+    assert p.number_to_words(1.5) == "one point five"
+    assert (
+        p.number_to_words(-0.000001) == "minus zero point zero zero zero zero zero one"
+    )
+    assert p.number_to_words(0.000001) == p.number_to_words("0.000001")


### PR DESCRIPTION
When a float like 0.000001 is passed to number_to_words, Python's str() converts it to '1e-06' which then gets parsed incorrectly, returning 'one hundred and six' instead of 'zero point zero zero zero zero zero one'.

This converts float inputs through Decimal(repr(num)) before formatting, which avoids scientific notation and preserves the intended decimal representation. Passing the same value as a string already worked fine, so this just makes the float path consistent with that.

Fixes #226