### PR TITLE
Fix TypeError in singular_noun for compound words with prepositions

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -3017,12 +3017,14 @@ class engine:
             " ".join(
                 itertools.chain(
                     leader,
-                    [inflection(cand, count), prep],  # type: ignore[operator]
+                    [inflected, prep],
                     trailer,
                 )
             )
             for leader, (cand, prep), trailer in windowed_complete(word.split_, 2)
             if prep in pl_prep_list_da
+            for inflected in [inflection(cand, count)]  # type: ignore[operator]
+            if isinstance(inflected, str)
         )
         return next(solutions, None)
 


### PR DESCRIPTION
`singular_noun` raises a `TypeError` when called with compound words where the head noun is already singular:

```python
>>> p.singular_noun("pair of scissors")
TypeError: sequence item 0: expected str instance, bool found
```

The problem is in `_handle_long_compounds`: it calls `_sinoun(cand, count)` and passes the result directly into `str.join()`. But `_sinoun` returns `False` when the word isn't recognized as a plural (e.g. "pair" is already singular). That `False` ends up in the join call, which only accepts strings.

The fix filters out non-string inflection results in the generator expression, so compound words with already-singular heads fall through to the caller's fallback path, returning the original word unchanged.

```python
>>> p.singular_noun("pair of scissors")
'pair of scissors'
>>> p.singular_noun("pairs of scissors")
'pair of scissors'
```

All 207 existing tests continue to pass.

Fixes #222
