### PR TITLE
Fix singular_noun for words ending in -ss

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -3495,6 +3495,11 @@ class engine:
         if word in si_sb_es_is:
             return word[:-2] + "is"
 
+        # WORDS ENDING IN -ss ARE ALREADY SINGULAR (e.g. grass, glass, moss)
+
+        if words.lowered[-2:] == "ss":
+            return False
+
         # OTHERWISE JUST REMOVE ...s
 
         if words.lowered[-1] == "s":

--- a/tests/test_singular_ss.py
+++ b/tests/test_singular_ss.py
@@ -1,0 +1,24 @@
+import pytest
+import inflect
+
+
+@pytest.mark.parametrize("word", ['grass', 'glass', 'underpass', 'boss', 'loss', 'moss', 'cross', 'dress', 'stress'])
+def test_singular_noun_ss_words(word):
+    """Words ending in -ss are already singular and should not be singularized further."""
+    p = inflect.engine()
+    assert p.singular_noun(word) is False
+
+
+@pytest.mark.parametrize("plural,singular", [
+    ('grasses', 'grass'),
+    ('glasses', 'glass'),
+    ('bosses', 'boss'),
+    ('losses', 'loss'),
+    ('mosses', 'moss'),
+    ('crosses', 'cross'),
+    ('dresses', 'dress'),
+])
+def test_singular_noun_sses_plurals(plural, singular):
+    """Plurals ending in -sses should still singularize correctly."""
+    p = inflect.engine()
+    assert p.singular_noun(plural) == singular


### PR DESCRIPTION
`singular_noun` returns wrong results for words ending in `-ss`:

```python
>>> p.singular_noun("grass")
'gras'
>>> p.singular_noun("glass")
'glas'
>>> p.singular_noun("boss")
'bos'
```

The problem is the catch-all rule at the end of `_sinoun` that strips a trailing `s` from any word. Words ending in `-ss` (like "grass", "glass", "boss", "moss", "cross", "dress") are already singular, so they shouldn't reach this rule.

The fix adds a check for `-ss` endings right before the catch-all, returning `False` since these words are already singular. Their plural forms (`grasses`, `glasses`, etc.) are still handled correctly by the earlier `-sses` rules.

All 223 existing tests continue to pass plus 16 new ones covering the fix.

Fixes #235
