### PR TITLE
Handle float singular counts

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,11 @@ Features
 
 - Updated `ast` classes for Python 3.14 compatibility. (#225)
 
+Bugfixes
+--------
+
+- Treat numeric values equal to ``1`` (such as ``1.0``) as singular counts.
+
 
 v7.4.0
 ======

--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2666,15 +2666,19 @@ class engine:
             )
         )
 
-    def get_count(self, count: Optional[Union[str, int]] = None) -> Union[str, int]:
+    def get_count(
+        self, count: Optional[Union[str, int, float]] = None
+    ) -> Union[str, int]:
         if count is None and self.persistent_count is not None:
             count = self.persistent_count
 
         if count is not None:
+            numeric_one = count == 1 and not isinstance(count, bool)
             count = (
                 1
                 if (
-                    (str(count) in pl_count_one)
+                    numeric_one
+                    or (str(count) in pl_count_one)
                     or (
                         self.classical_dict["zero"]
                         and str(count).lower() in pl_count_zero

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -534,6 +534,7 @@ class Test:
         p = inflect.engine()
         for txt, num in (
             (1, 1),
+            (1.0, 1),
             (2, 2),
             (0, 2),
             (87, 2),


### PR DESCRIPTION
﻿## Summary

- treat numeric counts equal to `1` (including `1.0`) as singular in `get_count()`
- preserve the existing bool behavior so `True` is not silently reclassified as a numeric singular count
- add a focused regression case and changelog note

## References

- Fixes #232

## Validation

- Not run locally
- relying on the repository's GitHub Actions checks for remote validation