### PR TITLE
Return whitespace-only input unchanged instead of raising IndexError

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2380,7 +2380,11 @@ class engine:
 
     def partition_word(self, text: str) -> Tuple[str, str, str]:
         mo = PARTITION_WORD.search(text)
-        if mo:
+        # A whitespace-only string matches with the middle group forced to a
+        # single space, which is truthy and slips past the callers' "no word"
+        # guard, later raising IndexError in Words(). Treat it as having no
+        # word, the same as the empty string.
+        if mo and mo.group(2).strip():
             return mo.group(1), mo.group(2), mo.group(3)
         else:
             return "", "", ""

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -228,12 +228,24 @@ class Test:
             ("  cow   ", ("  ", "cow", "   ")),
             ("", ("", "", "")),
             ("bottle of beer", ("", "bottle of beer", "")),
-            # spaces give weird results
-            # (' '),('', ' ', '')),
-            # ('  '),(' ', ' ', '')),
-            # ('   '),('  ', ' ', '')),
+            # whitespace-only input has no word, same as the empty string
+            (" ", ("", "", "")),
+            ("  ", ("", "", "")),
+            ("   ", ("", "", "")),
+            ("\t", ("", "", "")),
         ):
             assert p.partition_word(txt) == part
+
+    def test_plural_whitespace_only(self):
+        # A whitespace-only string has no word to inflect and used to raise
+        # IndexError; it should be returned unchanged.
+        p = inflect.engine()
+        for txt in (" ", "  ", "   ", "\t", "\n\t "):
+            assert p.plural(txt) == txt
+            assert p.plural_noun(txt) == txt
+            assert p.plural_verb(txt) == txt
+            assert p.plural_adj(txt) == txt
+            assert p.singular_noun(txt) == txt
 
     def test_pl(self):
         p = inflect.engine()


### PR DESCRIPTION
`inflect.engine().plural('  ')` (and other whitespace-only input to `plural`, `plural_noun`, `singular_noun`) raises `IndexError: list index out of range`.

`partition_word` matches a whitespace-only string with the middle 'word' group forced to a single space, which is truthy and slips past the callers' `if not word: return text` guard. `Words()` then splits it to an empty list and indexes it. The `Word` type only requires `len >= 1`, so a whitespace-only string is valid input.

Treat a whitespace-only match as having no word, the same as the empty string, so the input is returned unchanged. Un-comments the previously-disabled whitespace cases in `test_partition_word` (the "spaces give weird results" note) and adds a regression test.