### PR TITLE
Handle whitespace-only input in number_to_words

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -3822,7 +3822,8 @@ class engine:
 
     @staticmethod
     def _get_sign(num):
-        return {'+': 'plus', '-': 'minus'}.get(num.lstrip()[0], '')
+        # slice not index: a whitespace-only num strips to "" and has no [0].
+        return {'+': 'plus', '-': 'minus'}.get(num.lstrip()[:1], '')
 
     @typechecked
     def number_to_words(  # noqa: C901

--- a/tests/test_numwords.py
+++ b/tests/test_numwords.py
@@ -396,3 +396,18 @@ def test_issue_131():
     p = inflect.engine()
     for nth_word in inflect.nth_suff:
         assert p.number_to_words(nth_word) == "zero"
+
+
+def test_number_to_words_whitespace():
+    # A whitespace-only string is a valid Word (len >= 1) and used to raise a
+    # raw IndexError from _get_sign; it now degrades to "zero" like other
+    # non-numeric input (e.g. "abc").
+    p = inflect.engine()
+    assert p.number_to_words(" ") == "zero"
+    assert p.number_to_words("  ") == "zero"
+    assert p.number_to_words("\t") == "zero"
+    assert p.number_to_words("\n") == "zero"
+    assert p.number_to_words(" \t ") == "zero"
+    # a sign preceded by whitespace still resolves.
+    assert p.number_to_words("  -5") == "minus five"
+    assert p.number_to_words("  +3") == "plus three"


### PR DESCRIPTION
`number_to_words` raised a raw `IndexError` on a whitespace-only string:

```python
>>> import inflect
>>> inflect.engine().number_to_words(" ")
IndexError: string index out of range
```

`_get_sign` does `num.lstrip()[0]`, and `" ".lstrip()` is `""`, so `""[0]` crashes. A whitespace-only string is a valid `Word` (the type guard only rejects the empty string), and other non-numeric input already degrades gracefully (`number_to_words("abc")` returns `"zero"`). This slices instead of indexing so whitespace degrades the same way; signed and normal input are unchanged.
