### PR TITLE
Handle whitespace-only input in Words

### DIFF
--- a/inflect/__init__.py
+++ b/inflect/__init__.py
@@ -2045,8 +2045,9 @@ class Words(str):
     def __init__(self, orig) -> None:
         self.lowered = self.lower()
         self.split_ = self.split()
-        self.first = self.split_[0]
-        self.last = self.split_[-1]
+        # a whitespace-only string is a valid Word but splits to []; degrade first/last.
+        self.first = self.split_[0] if self.split_ else ""
+        self.last = self.split_[-1] if self.split_ else ""
 
 
 Falsish = Any  # ideally, falsish would only validate on bool(value) is False

--- a/newsfragments/263.bugfix.rst
+++ b/newsfragments/263.bugfix.rst
@@ -1,0 +1,1 @@
+``Words`` no longer raises ``IndexError`` on whitespace-only input; ``first`` and ``last`` degrade to an empty string.

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -502,6 +502,18 @@ class Test:
         p.defadj("my", "our|your")  # what's ours is yours
         assert p.compare("your", "our") == "p:p"
 
+    def test_compare_whitespace_only_degrades(self):
+        # Whitespace-only passes the Word guard (min_length=1) but splits to [].
+        p = inflect.engine()
+        assert p.compare(" ", "x") is False
+        assert p.compare("x", " ") is False
+        assert p.compare("  ", "\t") is False
+        assert p.compare_nouns(" ", "cats") is False
+        assert p.no("  ", 3) == " 3  S"
+        # equal words and normal words are unaffected.
+        assert p.compare(" ", " ") == "eq"
+        assert p.compare("cat", "cats") == "s:p"
+
     def test__pl_reg_plurals(self):
         p = inflect.engine()
         for pair, stems, end1, end2, ans in (


### PR DESCRIPTION
A whitespace-only string passes the `Word` type guard (`min_length=1`) but `str.split()` returns `[]`, so `Words.__init__` raised `IndexError` building `self.first`/`self.last`. Reachable through `compare`/`compare_nouns`:

```python
import inflect
inflect.engine().compare(" ", "x")  # was: IndexError
```

`first`/`last` now degrade to `""` for that case; normal words are unaffected.

Same class as #260 (`partition_word`) and #262 (`_get_sign`), in a different method.